### PR TITLE
Update pre-commit-config and add deps to pyproject

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,12 +1,4 @@
 repos:
-  - repo: https://github.com/python-poetry/poetry
-    rev: '1.2.1'  # add version here
-    hooks:
-      - id: poetry-check
-      - id: poetry-lock
-      - id: poetry-export
-        args: ["-f", "requirements.txt", "-o", "requirements.txt"]
-
   - repo: https://github.com/pre-commit/pre-commit-hooks
     rev: v4.3.0
     hooks:
@@ -18,6 +10,7 @@ repos:
       - id: check-toml
       - id: check-yaml
       - id: detect-aws-credentials
+        args: [--allow-missing-credentials]
       - id: detect-private-key
       - id: end-of-file-fixer
       - id: requirements-txt-fixer
@@ -29,7 +22,7 @@ repos:
     hooks:
       - id: pyupgrade
         args:
-          - --py38-plus
+          - --py311-plus
 
   -   repo: https://github.com/MarcoGorelli/absolufy-imports
       rev: v0.3.1
@@ -38,7 +31,7 @@ repos:
         name: absolufy-imports
 
   -   repo: https://github.com/pycqa/isort
-      rev: 5.10.1
+      rev: 5.13.2
       hooks:
       - id: isort
         args: ["--filter-files"]
@@ -51,3 +44,8 @@ repos:
         language_version: python3
         args:
           - --target-version=py38
+
+  - repo: https://github.com/kynan/nbstripout
+    rev: 0.8.1
+    hooks:
+      - id: nbstripout

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -43,7 +43,7 @@ repos:
       - id: black
         language_version: python3
         args:
-          - --target-version=py38
+          - --target-version=py311
 
   - repo: https://github.com/kynan/nbstripout
     rev: 0.8.1

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -68,6 +68,8 @@ all = [
   "sphinx_rtd_theme",
   "twine",
   "pandoc",
+  "pre-commit",
+  "nbstripout",
 ]
 
 [build-system]


### PR DESCRIPTION
Update the pre-commit config YAML file to include nbstripout. It also removes an old poetry config that was failing, and added a fix for the AWS credential check failing if it didn't find any valid credentials.

Add nbstripout and pre-commit to the pyproject [all] dependency list.