### PR TITLE
Make AstroVIPER notebooks work in colab (or any other env. where dependencies are not pre-installed)

### DIFF
--- a/docs/calibration_tutorials/astroviper_fringefit_tutorial.ipynb
+++ b/docs/calibration_tutorials/astroviper_fringefit_tutorial.ipynb
@@ -1,9 +1,50 @@
 {
  "cells": [
   {
+   "cell_type": "markdown",
+   "id": "0",
+   "metadata": {},
+   "source": [
+    "# Fringefit Demo\n",
+    "\n",
+    "[Colab Link](https://colab.research.google.com/github/casangi/astroviper/blob/main/docs/calibration_tutorials/astroviper_fringefit_turorial.ipynb)\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "1",
+   "metadata": {},
+   "source": [
+    "## Install AstroVIPER\n",
+    "\n",
+    "Skip this cell if you don't want to install the latest version of AstroVIPER."
+   ]
+  },
+  {
    "cell_type": "code",
    "execution_count": null,
-   "id": "0",
+   "id": "2",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import os\n",
+    "from importlib.metadata import version\n",
+    "\n",
+    "try:\n",
+    "    os.system(\"pip install --upgrade astroviper[all]\")\n",
+    "\n",
+    "    import astroviper  # noqa: F401 -- availability probe for the pip-install fallback\n",
+    "\n",
+    "    print(\"Using astroviper version\", version(\"astroviper\"))\n",
+    "\n",
+    "except ImportError as exc:\n",
+    "    print(f\"Could not import astroviper: {exc}\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "3",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -20,7 +61,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "1",
+   "id": "4",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -45,7 +86,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "2",
+   "id": "5",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -60,7 +101,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "3",
+   "id": "6",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -109,7 +150,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "4",
+   "id": "7",
    "metadata": {},
    "outputs": [],
    "source": []
@@ -117,7 +158,7 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "timg",
+   "display_name": "Python 3 (ipykernel)",
    "language": "python",
    "name": "python3"
   },

--- a/docs/distributed_applications_tutorials/image_analysis/generic_image_selection.ipynb
+++ b/docs/distributed_applications_tutorials/image_analysis/generic_image_selection.ipynb
@@ -7,6 +7,8 @@
    "source": [
     "# Image Region of Interest Selection (aka Masking)\n",
     "\n",
+    "[Colab Link](https://colab.research.google.com/github/casangi/astroviper/blob/main/docs/distributed_applications_tutorials/image_analysis/generic_image_selection.ipynb)\n",
+    "\n",
     "In this tutorial, you will learn about how to select regions of interest as well as how to create and apply image masks based on pixel values. These two concepts are actually the same in that they involve flagging sets of pixels as bad. The main difference is semantic\n",
     "* A region of interest is just a way to flag pixels as good/bad based on coordinate values, rather than pixel values. For example, selecting circular, rectangular, and polygonal areas are region selections.\n",
     "\n",
@@ -33,9 +35,40 @@
    ]
   },
   {
+   "cell_type": "markdown",
+   "id": "2",
+   "metadata": {},
+   "source": [
+    "## Install AstroVIPER\n",
+    "\n",
+    "Skip this cell if you don't want to install the latest version of AstroVIPER."
+   ]
+  },
+  {
    "cell_type": "code",
    "execution_count": null,
-   "id": "2",
+   "id": "3",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import os\n",
+    "from importlib.metadata import version\n",
+    "\n",
+    "try:\n",
+    "    os.system(\"pip install --upgrade astroviper[all]\")\n",
+    "\n",
+    "    import astroviper  # noqa: F401 -- availability probe for the pip-install fallback\n",
+    "\n",
+    "    print(\"Using astroviper version\", version(\"astroviper\"))\n",
+    "\n",
+    "except ImportError as exc:\n",
+    "    print(f\"Could not import astroviper: {exc}\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "4",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -57,7 +90,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "3",
+   "id": "5",
    "metadata": {},
    "source": [
     "We start by simulating a source based on a 2d elliptical gaussian model with a uniform additive level across the image. We will use xr.DataArrays for the most part, however, there is similar support for flagging for dask and numpy arrays."
@@ -66,7 +99,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "4",
+   "id": "6",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -88,7 +121,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "5",
+   "id": "7",
    "metadata": {},
    "source": [
     "Plot the model source"
@@ -97,7 +130,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "6",
+   "id": "8",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -141,7 +174,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "7",
+   "id": "9",
    "metadata": {},
    "source": [
     "## Primary methods\n",
@@ -152,7 +185,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "8",
+   "id": "10",
    "metadata": {},
    "source": [
     "## **select=None** → use everything, all pixels are good.\n",
@@ -162,7 +195,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "9",
+   "id": "11",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -172,7 +205,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "10",
+   "id": "12",
    "metadata": {},
    "source": [
     "To generate a boolean flag that can be applied to an array later, use **select_mask()**. Because there is no selection in this case,\n",
@@ -182,7 +215,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "11",
+   "id": "13",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -192,7 +225,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "12",
+   "id": "14",
    "metadata": {},
    "source": [
     "## Boolean array-like (DataArray or ndarray selection)\n",
@@ -202,7 +235,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "13",
+   "id": "15",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -217,7 +250,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "14",
+   "id": "16",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -231,7 +264,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "15",
+   "id": "17",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -242,7 +275,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "16",
+   "id": "18",
    "metadata": {},
    "source": [
     "## Build masks from combinations of other masks\n",
@@ -254,7 +287,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "17",
+   "id": "19",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -265,7 +298,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "18",
+   "id": "20",
    "metadata": {},
    "source": [
     "Now, create a region of interest that is confined\n",
@@ -275,7 +308,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "19",
+   "id": "21",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -286,7 +319,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "20",
+   "id": "22",
    "metadata": {},
    "source": [
     "Now combine the circular region, the threshholded mask, and the image center strip in an expression represented by a string."
@@ -295,7 +328,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "21",
+   "id": "23",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -315,7 +348,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "22",
+   "id": "24",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -328,14 +361,14 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "23",
+   "id": "25",
    "metadata": {},
    "outputs": [],
    "source": []
   },
   {
    "cell_type": "markdown",
-   "id": "24",
+   "id": "26",
    "metadata": {},
    "source": [
     "## CRTF (CASA 6) region support.\n",
@@ -346,7 +379,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "25",
+   "id": "27",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -367,7 +400,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "26",
+   "id": "28",
    "metadata": {},
    "source": [
     "Utility to overlay masks"
@@ -376,7 +409,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "27",
+   "id": "29",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -399,7 +432,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "28",
+   "id": "30",
    "metadata": {},
    "source": [
     "### Box region\n",
@@ -413,7 +446,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "29",
+   "id": "31",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -437,7 +470,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "30",
+   "id": "32",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -448,7 +481,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "31",
+   "id": "33",
    "metadata": {},
    "source": [
     "Apply the regions."
@@ -457,7 +490,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "32",
+   "id": "34",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -470,7 +503,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "33",
+   "id": "35",
    "metadata": {},
    "source": [
     "### Rotated box (rotbox)\n",
@@ -484,7 +517,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "34",
+   "id": "36",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -496,7 +529,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "35",
+   "id": "37",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -506,7 +539,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "36",
+   "id": "38",
    "metadata": {},
    "source": [
     "Here we use the mode of pa, so that the rotation angle is measured from +y -> +x"
@@ -515,7 +548,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "37",
+   "id": "39",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -527,7 +560,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "38",
+   "id": "40",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -537,7 +570,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "39",
+   "id": "41",
    "metadata": {},
    "source": [
     "### Circle and annulus\n",
@@ -548,7 +581,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "40",
+   "id": "42",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -563,7 +596,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "41",
+   "id": "43",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -577,14 +610,14 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "42",
+   "id": "44",
    "metadata": {},
    "outputs": [],
    "source": []
   },
   {
    "cell_type": "markdown",
-   "id": "43",
+   "id": "45",
    "metadata": {},
    "source": [
     "### Ellipse with position angle\n",
@@ -598,7 +631,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "44",
+   "id": "46",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -610,7 +643,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "45",
+   "id": "47",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -620,7 +653,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "46",
+   "id": "48",
    "metadata": {},
    "source": [
     "In the following example, we use pa rotation angle convention (+y -> +x)"
@@ -629,7 +662,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "47",
+   "id": "49",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -641,7 +674,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "48",
+   "id": "50",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -651,7 +684,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "49",
+   "id": "51",
    "metadata": {},
    "source": [
     "### Polygon (poly)\n",
@@ -661,7 +694,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "50",
+   "id": "52",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -673,7 +706,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "51",
+   "id": "53",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -683,7 +716,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "52",
+   "id": "54",
    "metadata": {},
    "source": [
     "## Multiple CRTF specifications with `+` (OR) and `-` (subtract)\n",
@@ -693,7 +726,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "53",
+   "id": "55",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -710,28 +743,10 @@
   },
   {
    "cell_type": "markdown",
-   "id": "54",
-   "metadata": {},
-   "source": [
-    "And the creation attr"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "55",
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "print(f\"Multi region creation attr\\n{mask_multi.attrs['creation']}\")"
-   ]
-  },
-  {
-   "cell_type": "markdown",
    "id": "56",
    "metadata": {},
    "source": [
-    "Apply selection to the image and compute simple stats"
+    "And the creation attr"
    ]
   },
   {
@@ -741,13 +756,31 @@
    "metadata": {},
    "outputs": [],
    "source": [
+    "print(f\"Multi region creation attr\\n{mask_multi.attrs['creation']}\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "58",
+   "metadata": {},
+   "source": [
+    "Apply selection to the image and compute simple stats"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "59",
+   "metadata": {},
+   "outputs": [],
+   "source": [
     "sel_multi = apply_select(z, select=multi)\n",
     "plot(sel_multi, title=\"Mulipte CRTF\")"
    ]
   },
   {
    "cell_type": "markdown",
-   "id": "58",
+   "id": "60",
    "metadata": {},
    "source": [
     "### Mixing CRTF with named-mask expressions\n",
@@ -761,7 +794,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "59",
+   "id": "61",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -779,7 +812,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "60",
+   "id": "62",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -789,7 +822,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "61",
+   "id": "63",
    "metadata": {},
    "source": [
     "Here we use `roi & -edge`. Note the minus sign which negates the selection; **edge** is excluded from the region selection. The order of operations is that `-` is executed prior to `&`, or in general before any combination operator."
@@ -798,7 +831,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "62",
+   "id": "64",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -810,7 +843,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "63",
+   "id": "65",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -820,7 +853,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "64",
+   "id": "66",
    "metadata": {},
    "source": [
     "Here we OR (|) the regions together, which results in the union of the two regions"
@@ -829,7 +862,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "65",
+   "id": "67",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -841,7 +874,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "66",
+   "id": "68",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -851,7 +884,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "67",
+   "id": "69",
    "metadata": {},
    "source": [
     "Here we create the union of roi and the negation of edge."
@@ -860,7 +893,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "68",
+   "id": "70",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -872,7 +905,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "69",
+   "id": "71",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -882,7 +915,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "70",
+   "id": "72",
    "metadata": {},
    "source": [
     "## Using CRTF **files** with `select_mask`\n",
@@ -891,7 +924,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "71",
+   "id": "73",
    "metadata": {},
    "source": [
     "### Write a CRTF file to disk\n",
@@ -901,7 +934,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "72",
+   "id": "74",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -920,7 +953,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "73",
+   "id": "75",
    "metadata": {},
    "source": [
     "### Two supported ways to load the CRTF file\n",
@@ -931,7 +964,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "74",
+   "id": "76",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -946,7 +979,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "75",
+   "id": "77",
    "metadata": {},
    "source": [
     "### Compare against the same CRTF provided inline as a string"
@@ -955,7 +988,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "76",
+   "id": "78",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -969,7 +1002,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "77",
+   "id": "79",
    "metadata": {},
    "source": [
     "### Apply the selection to the image"
@@ -978,7 +1011,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "78",
+   "id": "80",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -988,7 +1021,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "79",
+   "id": "81",
    "metadata": {},
    "source": [
     "## Selection masks: inputs × outputs\n",
@@ -1003,7 +1036,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "80",
+   "id": "82",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1020,7 +1053,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "81",
+   "id": "83",
    "metadata": {},
    "source": [
     "### Create sample data (NumPy, DataArray[NumPy], DataArray[Dask])"
@@ -1029,7 +1062,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "82",
+   "id": "84",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1047,7 +1080,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "83",
+   "id": "85",
    "metadata": {},
    "source": [
     "### Define selections: CRTF (pixel) and expressions"
@@ -1056,7 +1089,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "84",
+   "id": "86",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1079,7 +1112,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "85",
+   "id": "87",
    "metadata": {},
    "source": [
     "### NumPy data → all return kinds (CRTF example)"
@@ -1088,7 +1121,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "86",
+   "id": "88",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1102,7 +1135,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "87",
+   "id": "89",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1128,7 +1161,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "88",
+   "id": "90",
    "metadata": {},
    "source": [
     "### Dask data → all return kinds (CRTF example)"
@@ -1137,7 +1170,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "89",
+   "id": "91",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1163,7 +1196,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "90",
+   "id": "92",
    "metadata": {},
    "source": [
     "### DataArray[NumPy] data → all return kinds (expression example)"
@@ -1172,7 +1205,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "91",
+   "id": "93",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1202,7 +1235,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "92",
+   "id": "94",
    "metadata": {},
    "source": [
     "### DataArray[Dask] data → all return kinds (CRTF example)"
@@ -1211,7 +1244,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "93",
+   "id": "95",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1237,7 +1270,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "94",
+   "id": "96",
    "metadata": {},
    "source": [
     "### Applying selections to data"
@@ -1246,7 +1279,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "95",
+   "id": "97",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1264,7 +1297,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "96",
+   "id": "98",
    "metadata": {},
    "source": [
     "### CRTF file usage: backticked path and `Path`"
@@ -1273,7 +1306,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "97",
+   "id": "99",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1308,7 +1341,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "98",
+   "id": "100",
    "metadata": {},
    "source": [
     "### Laziness and compute()\n",
@@ -1319,7 +1352,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "99",
+   "id": "101",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1335,7 +1368,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "100",
+   "id": "102",
    "metadata": {},
    "source": [
     "### Selection “creation” attribute demo\n",
@@ -1346,7 +1379,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "101",
+   "id": "103",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1357,7 +1390,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "102",
+   "id": "104",
    "metadata": {},
    "source": [
     "### Inline CRTF string ⇒ DataArray with `attrs[\"creation\"]`"
@@ -1366,7 +1399,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "103",
+   "id": "105",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1388,7 +1421,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "104",
+   "id": "106",
    "metadata": {},
    "source": [
     "### CRTF file (backticked string and `Path`) ⇒ creation reflects how it was referenced"
@@ -1397,7 +1430,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "105",
+   "id": "107",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1419,7 +1452,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "106",
+   "id": "108",
    "metadata": {},
    "source": [
     "### Expression over named masks ⇒ `creation` equals the expression string"
@@ -1428,7 +1461,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "107",
+   "id": "109",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1448,7 +1481,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "108",
+   "id": "110",
    "metadata": {},
    "source": [
     "### Combining masks with bitwise ops\n",
@@ -1459,7 +1492,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "109",
+   "id": "111",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1479,7 +1512,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "110",
+   "id": "112",
    "metadata": {},
    "source": [
     "### Quick sanity: `creation` preserved with different return kinds\n",
@@ -1491,7 +1524,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "111",
+   "id": "113",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1512,7 +1545,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "112",
+   "id": "114",
    "metadata": {},
    "source": [
     "### Suggested pattern for building complex masks with readable provenance\n",
@@ -1525,7 +1558,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "113",
+   "id": "115",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1542,7 +1575,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "114",
+   "id": "116",
    "metadata": {},
    "source": [
     "### `creation_hint` demos"
@@ -1551,7 +1584,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "115",
+   "id": "117",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1561,7 +1594,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "116",
+   "id": "118",
    "metadata": {},
    "source": [
     "### CRTF inline — default creation vs. override with `creation_hint`"
@@ -1570,7 +1603,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "117",
+   "id": "119",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1594,7 +1627,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "118",
+   "id": "120",
    "metadata": {},
    "source": [
     "### CRTF file (backticked/path) — creation is file **contents**, can be overridden"
@@ -1603,7 +1636,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "119",
+   "id": "121",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1630,7 +1663,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "120",
+   "id": "122",
    "metadata": {},
    "source": [
     "### Expression over named masks — expanded creation vs. override"
@@ -1639,7 +1672,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "121",
+   "id": "123",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1668,7 +1701,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "122",
+   "id": "124",
    "metadata": {},
    "source": [
     "## Creation provenance for selections: `creation_hint` and `combine_with_creation`"
@@ -1676,7 +1709,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "123",
+   "id": "125",
    "metadata": {},
    "source": [
     "These cells demonstrate how to attach human-readable provenance to masks created from non-CRTF sources, and how to combine masks while preserving and merging their creation strings."
@@ -1685,7 +1718,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "124",
+   "id": "126",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1695,7 +1728,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "125",
+   "id": "127",
    "metadata": {},
    "source": [
     "### Non-CRTF masks with `creation_hint`\n",
@@ -1706,7 +1739,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "126",
+   "id": "128",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1746,7 +1779,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "127",
+   "id": "129",
    "metadata": {},
    "source": [
     "### Expressions with an optional `creation_hint` override\n",
@@ -1757,7 +1790,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "128",
+   "id": "130",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1786,7 +1819,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "129",
+   "id": "131",
    "metadata": {},
    "source": [
     "### `combine_with_creation`: merge masks and provenance\n",
@@ -1797,7 +1830,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "130",
+   "id": "132",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1829,7 +1862,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "131",
+   "id": "133",
    "metadata": {},
    "source": [
     "### Preserving provenance when changing return kind\n",
@@ -1840,7 +1873,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "132",
+   "id": "134",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1856,7 +1889,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "133",
+   "id": "135",
    "metadata": {},
    "source": [
     "## Combine CRTF file-based masks with inline CRTF and with non-CRTF boolean masks (preserving `creation`)"
@@ -1865,7 +1898,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "134",
+   "id": "136",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1876,7 +1909,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "135",
+   "id": "137",
    "metadata": {},
    "source": [
     "### Build two CRTF masks\n",
@@ -1887,7 +1920,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "136",
+   "id": "138",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1927,7 +1960,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "137",
+   "id": "139",
    "metadata": {},
    "source": [
     "### Combine **file-based** and **inline** CRTF masks\n",
@@ -1939,7 +1972,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "138",
+   "id": "140",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1959,7 +1992,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "139",
+   "id": "141",
    "metadata": {},
    "source": [
     "### Create a **non-CRTF** boolean mask with a `creation_hint`\n",
@@ -1970,7 +2003,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "140",
+   "id": "142",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1998,7 +2031,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "141",
+   "id": "143",
    "metadata": {},
    "source": [
     "### Combine the **CRTF (file|inline)** mask with a **non-CRTF** mask\n",
@@ -2012,7 +2045,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "142",
+   "id": "144",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -2032,7 +2065,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "143",
+   "id": "145",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -2048,7 +2081,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "144",
+   "id": "146",
    "metadata": {},
    "source": [
     "### (Optional) Coerce to NumPy-backed while **preserving** `creation`\n",
@@ -2060,7 +2093,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "145",
+   "id": "147",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -2093,7 +2126,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.12.9"
+   "version": "3.13.7"
   }
  },
  "nbformat": 4,

--- a/docs/distributed_applications_tutorials/image_analysis/image_selection.ipynb
+++ b/docs/distributed_applications_tutorials/image_analysis/image_selection.ipynb
@@ -7,6 +7,8 @@
    "source": [
     "# Image Selection (aka Masking)\n",
     "\n",
+    "[Colab Link](https://colab.research.google.com/github/casangi/astroviper/blob/main/docs/distributed_applications_tutorials/image_analysis/image_selection.ipynb)\n",
+    "\n",
     "In this tutorial, you will learn about how to select regions of interest\n",
     "in images and how to exclude images with masks. The following ways exist\n",
     "to create regions/masks:\n",
@@ -17,9 +19,40 @@
    ]
   },
   {
+   "cell_type": "markdown",
+   "id": "1",
+   "metadata": {},
+   "source": [
+    "## Install AstroVIPER\n",
+    "\n",
+    "Skip this cell if you don't want to install the latest version of AstroVIPER."
+   ]
+  },
+  {
    "cell_type": "code",
    "execution_count": null,
-   "id": "1",
+   "id": "2",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import os\n",
+    "from importlib.metadata import version\n",
+    "\n",
+    "try:\n",
+    "    os.system(\"pip install --upgrade astroviper[all]\")\n",
+    "\n",
+    "    import astroviper  # noqa: F401 -- availability probe for the pip-install fallback\n",
+    "\n",
+    "    print(\"Using astroviper version\", version(\"astroviper\"))\n",
+    "\n",
+    "except ImportError as exc:\n",
+    "    print(f\"Could not import astroviper: {exc}\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "3",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -40,7 +73,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "2",
+   "id": "4",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -61,7 +94,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "3",
+   "id": "5",
    "metadata": {},
    "source": [
     "Create and plot a model source"
@@ -70,7 +103,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "4",
+   "id": "6",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -83,7 +116,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "5",
+   "id": "7",
    "metadata": {},
    "source": [
     "## **select=None** → use everything"
@@ -92,7 +125,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "6",
+   "id": "8",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -111,7 +144,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "7",
+   "id": "9",
    "metadata": {},
    "source": [
     "## Boolean array-like (DataArray or ndarray selection)\n",
@@ -121,7 +154,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "8",
+   "id": "10",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -149,7 +182,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "9",
+   "id": "11",
    "metadata": {},
    "source": [
     "## String expression over named masks (\"roi & ~bad & ~sidelobe\")\n",
@@ -159,7 +192,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "10",
+   "id": "12",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -215,7 +248,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "11",
+   "id": "13",
    "metadata": {},
    "source": [
     "## CRTF (CASA 6) region support.\n",
@@ -226,7 +259,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "12",
+   "id": "14",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -246,7 +279,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "13",
+   "id": "15",
    "metadata": {},
    "source": [
     "Utility to overlay masks"
@@ -255,7 +288,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "14",
+   "id": "16",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -278,7 +311,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "15",
+   "id": "17",
    "metadata": {},
    "source": [
     "## Box region\n",
@@ -289,7 +322,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "16",
+   "id": "18",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -311,7 +344,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "17",
+   "id": "19",
    "metadata": {},
    "source": [
     "Apply the regions."
@@ -320,7 +353,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "18",
+   "id": "20",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -340,7 +373,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "19",
+   "id": "21",
    "metadata": {},
    "source": [
     "## Rotated box (rotbox)\n",
@@ -354,7 +387,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "20",
+   "id": "22",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -369,7 +402,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "21",
+   "id": "23",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -383,7 +416,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "22",
+   "id": "24",
    "metadata": {},
    "source": [
     "Here we use the mode of pa, so that the rotation angle is measured from +y -> +x"
@@ -392,7 +425,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "23",
+   "id": "25",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -407,7 +440,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "24",
+   "id": "26",
    "metadata": {},
    "outputs": [],
    "source": []
@@ -415,7 +448,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "25",
+   "id": "27",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -429,7 +462,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "26",
+   "id": "28",
    "metadata": {},
    "source": [
     "## Circle and annulus"
@@ -438,7 +471,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "27",
+   "id": "29",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -456,7 +489,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "28",
+   "id": "30",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -474,14 +507,14 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "29",
+   "id": "31",
    "metadata": {},
    "outputs": [],
    "source": []
   },
   {
    "cell_type": "markdown",
-   "id": "30",
+   "id": "32",
    "metadata": {},
    "source": [
     "## Ellipse with position angle\n",
@@ -495,7 +528,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "31",
+   "id": "33",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -510,7 +543,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "32",
+   "id": "34",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -524,7 +557,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "33",
+   "id": "35",
    "metadata": {},
    "source": [
     "In the following example, we use pa rotation angle convention (+y -> +x)"
@@ -533,7 +566,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "34",
+   "id": "36",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -548,7 +581,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "35",
+   "id": "37",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -562,7 +595,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "36",
+   "id": "38",
    "metadata": {},
    "source": [
     "## Polygon (poly)"
@@ -571,7 +604,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "37",
+   "id": "39",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -586,7 +619,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "38",
+   "id": "40",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -600,7 +633,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "39",
+   "id": "41",
    "metadata": {},
    "source": [
     "## Multiple CRTF specifications with `+` (OR) and `-` (subtract)\n",
@@ -610,7 +643,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "40",
+   "id": "42",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -630,7 +663,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "41",
+   "id": "43",
    "metadata": {},
    "source": [
     "Apply selection to the image and compute simple stats"
@@ -639,7 +672,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "42",
+   "id": "44",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -656,7 +689,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "43",
+   "id": "45",
    "metadata": {},
    "source": [
     "### Mixing CRTF with named-mask expressions\n",
@@ -670,7 +703,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "44",
+   "id": "46",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -690,7 +723,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "45",
+   "id": "47",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -704,7 +737,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "46",
+   "id": "48",
    "metadata": {},
    "source": [
     "Here we use `roi & -edge` (note the minus sign which negates the selection; **edge**\n",
@@ -714,7 +747,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "47",
+   "id": "49",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -729,7 +762,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "48",
+   "id": "50",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -743,7 +776,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "49",
+   "id": "51",
    "metadata": {},
    "source": [
     "Here we OR (|) the regions together, which results in the union of the two regions"
@@ -752,7 +785,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "50",
+   "id": "52",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -767,7 +800,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "51",
+   "id": "53",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -781,7 +814,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "52",
+   "id": "54",
    "metadata": {},
    "source": [
     "Here we create the union of roi and the negation of edge."
@@ -790,7 +823,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "53",
+   "id": "55",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -805,7 +838,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "54",
+   "id": "56",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -819,7 +852,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "55",
+   "id": "57",
    "metadata": {},
    "source": [
     "## Using CRTF files with `select_mask`\n",
@@ -833,7 +866,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "56",
+   "id": "58",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -852,7 +885,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "57",
+   "id": "59",
    "metadata": {},
    "source": [
     "### Write a CRTF file to disk\n",
@@ -862,7 +895,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "58",
+   "id": "60",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -881,7 +914,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "59",
+   "id": "61",
    "metadata": {},
    "source": [
     "### Load the CRTF file in two supported ways\n",
@@ -892,7 +925,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "60",
+   "id": "62",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -910,7 +943,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "61",
+   "id": "63",
    "metadata": {},
    "source": [
     "### Compare against the same CRTF provided inline as a string"
@@ -919,7 +952,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "62",
+   "id": "64",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -930,7 +963,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "63",
+   "id": "65",
    "metadata": {},
    "source": [
     "### Visualize — make boundaries obvious"
@@ -939,7 +972,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "64",
+   "id": "66",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -965,7 +998,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "65",
+   "id": "67",
    "metadata": {},
    "source": [
     "### Apply the selection to the image"
@@ -974,7 +1007,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "66",
+   "id": "68",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -993,7 +1026,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "67",
+   "id": "69",
    "metadata": {},
    "source": [
     "# Selection masks: inputs × outputs\n",
@@ -1008,7 +1041,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "68",
+   "id": "70",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1056,7 +1089,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "69",
+   "id": "71",
    "metadata": {},
    "source": [
     "## Create sample data (NumPy, DataArray[NumPy], DataArray[Dask])"
@@ -1065,7 +1098,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "70",
+   "id": "72",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1083,7 +1116,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "71",
+   "id": "73",
    "metadata": {},
    "source": [
     "## Define selections: CRTF (pixel) and expressions"
@@ -1092,7 +1125,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "72",
+   "id": "74",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1118,7 +1151,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "73",
+   "id": "75",
    "metadata": {},
    "source": [
     "## NumPy data → all return kinds"
@@ -1127,7 +1160,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "74",
+   "id": "76",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1154,7 +1187,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "75",
+   "id": "77",
    "metadata": {},
    "source": [
     "## DataArray[NumPy] data → all return kinds (expression path)"
@@ -1163,7 +1196,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "76",
+   "id": "78",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1193,7 +1226,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "77",
+   "id": "79",
    "metadata": {},
    "source": [
     "## DataArray[Dask] data → all return kinds (CRTF path)"
@@ -1202,7 +1235,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "78",
+   "id": "80",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1228,7 +1261,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "79",
+   "id": "81",
    "metadata": {},
    "source": [
     "## Applying selections to data"
@@ -1237,7 +1270,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "80",
+   "id": "82",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1254,7 +1287,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "81",
+   "id": "83",
    "metadata": {},
    "source": [
     "## CRTF file usage: backticked path and `Path`"
@@ -1263,7 +1296,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "82",
+   "id": "84",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1294,7 +1327,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "83",
+   "id": "85",
    "metadata": {},
    "source": [
     "## Laziness and compute()"
@@ -1303,7 +1336,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "84",
+   "id": "86",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1319,7 +1352,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "85",
+   "id": "87",
    "metadata": {},
    "source": [
     "# Selection “creation” attribute demo\n",
@@ -1330,7 +1363,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "86",
+   "id": "88",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1341,7 +1374,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "87",
+   "id": "89",
    "metadata": {},
    "source": [
     "## Inline CRTF string ⇒ DataArray with `attrs[\"creation\"]`"
@@ -1350,7 +1383,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "88",
+   "id": "90",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1372,7 +1405,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "89",
+   "id": "91",
    "metadata": {},
    "source": [
     "## CRTF file (backticked string and `Path`) ⇒ creation reflects how it was referenced"
@@ -1381,7 +1414,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "90",
+   "id": "92",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1403,7 +1436,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "91",
+   "id": "93",
    "metadata": {},
    "source": [
     "## Expression over named masks ⇒ `creation` equals the expression string"
@@ -1412,7 +1445,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "92",
+   "id": "94",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1432,7 +1465,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "93",
+   "id": "95",
    "metadata": {},
    "source": [
     "## Combining masks with bitwise ops\n",
@@ -1443,7 +1476,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "94",
+   "id": "96",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1458,7 +1491,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "95",
+   "id": "97",
    "metadata": {},
    "source": [
     "## Quick sanity: `creation` preserved with different return kinds\n",
@@ -1470,7 +1503,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "96",
+   "id": "98",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1491,7 +1524,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "97",
+   "id": "99",
    "metadata": {},
    "source": [
     "## Suggested pattern for building complex masks with readable provenance\n",
@@ -1504,7 +1537,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "98",
+   "id": "100",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1521,7 +1554,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "99",
+   "id": "101",
    "metadata": {},
    "source": [
     "# `creation_hint` demos (non-invasive, copy/paste cells)"
@@ -1530,7 +1563,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "100",
+   "id": "102",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1540,7 +1573,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "101",
+   "id": "103",
    "metadata": {},
    "source": [
     "## CRTF inline — default creation vs. override with `creation_hint`"
@@ -1549,7 +1582,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "102",
+   "id": "104",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1573,7 +1606,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "103",
+   "id": "105",
    "metadata": {},
    "source": [
     "## CRTF file (backticked/path) — creation is file **contents**, can be overridden"
@@ -1582,7 +1615,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "104",
+   "id": "106",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1609,7 +1642,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "105",
+   "id": "107",
    "metadata": {},
    "source": [
     "## Expression over named masks — expanded creation vs. override"
@@ -1618,7 +1651,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "106",
+   "id": "108",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1647,7 +1680,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "107",
+   "id": "109",
    "metadata": {},
    "source": [
     "# Creation provenance for selections: `creation_hint` and `combine_with_creation`"
@@ -1655,7 +1688,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "108",
+   "id": "110",
    "metadata": {},
    "source": [
     "These cells demonstrate how to attach human-readable provenance to masks created from non-CRTF sources, and how to combine masks while preserving and merging their creation strings."
@@ -1664,7 +1697,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "109",
+   "id": "111",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1674,7 +1707,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "110",
+   "id": "112",
    "metadata": {},
    "source": [
     "## Non-CRTF masks with `creation_hint`\n",
@@ -1685,7 +1718,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "111",
+   "id": "113",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1724,7 +1757,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "112",
+   "id": "114",
    "metadata": {},
    "source": [
     "## Expressions with an optional `creation_hint` override\n",
@@ -1735,7 +1768,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "113",
+   "id": "115",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1764,7 +1797,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "114",
+   "id": "116",
    "metadata": {},
    "source": [
     "## `combine_with_creation`: merge masks and provenance\n",
@@ -1775,7 +1808,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "115",
+   "id": "117",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1807,7 +1840,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "116",
+   "id": "118",
    "metadata": {},
    "source": [
     "## Preserving provenance when changing return kind\n",
@@ -1818,7 +1851,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "117",
+   "id": "119",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1834,7 +1867,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "118",
+   "id": "120",
    "metadata": {},
    "source": [
     "# Combine CRTF file-based masks with inline CRTF and with non-CRTF boolean masks (preserving `creation`)"
@@ -1843,7 +1876,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "119",
+   "id": "121",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1854,7 +1887,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "120",
+   "id": "122",
    "metadata": {},
    "source": [
     "## Build two CRTF masks\n",
@@ -1865,7 +1898,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "121",
+   "id": "123",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1905,7 +1938,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "122",
+   "id": "124",
    "metadata": {},
    "source": [
     "## Combine **file-based** and **inline** CRTF masks\n",
@@ -1917,7 +1950,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "123",
+   "id": "125",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1937,7 +1970,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "124",
+   "id": "126",
    "metadata": {},
    "source": [
     "## Create a **non-CRTF** boolean mask with a `creation_hint`\n",
@@ -1948,7 +1981,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "125",
+   "id": "127",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1976,7 +2009,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "126",
+   "id": "128",
    "metadata": {},
    "source": [
     "## Combine the **CRTF (file|inline)** mask with a **non-CRTF** mask\n",
@@ -1990,7 +2023,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "127",
+   "id": "129",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -2009,7 +2042,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "128",
+   "id": "130",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -2025,7 +2058,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "129",
+   "id": "131",
    "metadata": {},
    "source": [
     "## (Optional) Coerce to NumPy-backed while **preserving** `creation`\n",
@@ -2037,7 +2070,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "130",
+   "id": "132",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -2070,7 +2103,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.12.9"
+   "version": "3.13.7"
   }
  },
  "nbformat": 4,

--- a/docs/distributed_applications_tutorials/image_analysis/imfit.ipynb
+++ b/docs/distributed_applications_tutorials/image_analysis/imfit.ipynb
@@ -8,7 +8,7 @@
     "# Image-Plane Gaussian Fitting with `imfit`\n",
     "## Dave Mehringer, April 2026\n",
     "\n",
-    "[Open in Colab](https://colab.research.google.com/github/casangi/astroviper/blob/main/docs/core_tutorials/image_analysis/imfit.ipynb)\n",
+    "[Open in Colab](https://colab.research.google.com/github/casangi/astroviper/blob/main/docs/distributed_applications_tutorials/image_analysis/imfit.ipynb)\n",
     "\n",
     "This notebook demonstrates `imfit`, the astronomer-facing 2-D Gaussian fitter\n",
     "for xradio image Datasets. It covers:\n",
@@ -26,8 +26,7 @@
    "source": [
     "## Install AstroVIPER\n",
     "\n",
-    "This cell only installs AstroVIPER when running in Google Colab.\n",
-    "Skip or ignore it when running locally."
+    "Skip this cell if you don't want to install the latest version of AstroVIPER."
    ]
   },
   {
@@ -37,22 +36,18 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "try:\n",
-    "    import google.colab  # noqa: F401\n",
-    "\n",
-    "    IN_COLAB = True\n",
-    "except ImportError:\n",
-    "    IN_COLAB = False\n",
-    "\n",
-    "if IN_COLAB:\n",
-    "    import os\n",
-    "\n",
-    "    os.system(\"pip install --upgrade astroviper\")\n",
-    "\n",
+    "import os\n",
     "from importlib.metadata import version\n",
     "\n",
-    "print(f\"Running in Colab: {IN_COLAB}\")\n",
-    "print(f\"astroviper version: {version('astroviper')}\")"
+    "try:\n",
+    "    os.system(\"pip install --upgrade astroviper[all]\")\n",
+    "\n",
+    "    import astroviper  # noqa: F401 -- availability probe for the pip-install fallback\n",
+    "\n",
+    "    print(\"Using astroviper version\", version(\"astroviper\"))\n",
+    "\n",
+    "except ImportError as exc:\n",
+    "    print(f\"Could not import astroviper: {exc}\")"
    ]
   },
   {
@@ -689,7 +684,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.13.12"
+   "version": "3.13.7"
   }
  },
  "nbformat": 4,

--- a/docs/distributed_applications_tutorials/image_analysis/moments.ipynb
+++ b/docs/distributed_applications_tutorials/image_analysis/moments.ipynb
@@ -84,25 +84,12 @@
     "    consolidate Zarr metadata; return the per-task timing DataFrame\n",
     "```\n",
     "\n",
-    "---\n",
-    "## API\n"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "2",
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "from astroviper.distributed_applications.image_analysis import moments\n",
-    "\n",
-    "moments?"
+    "---"
    ]
   },
   {
    "cell_type": "markdown",
-   "id": "3",
+   "id": "2",
    "metadata": {},
    "source": [
     "## Install AstroVIPER\n",
@@ -113,7 +100,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "4",
+   "id": "3",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -121,19 +108,39 @@
     "from importlib.metadata import version\n",
     "\n",
     "try:\n",
+    "    os.system(\"pip install --upgrade astroviper[all]\")\n",
+    "\n",
     "    import astroviper  # noqa: F401 -- availability probe for the pip-install fallback\n",
     "\n",
     "    print(\"Using astroviper version\", version(\"astroviper\"))\n",
-    "except ImportError:\n",
-    "    os.system(\"pip install --upgrade astroviper\")\n",
-    "    import astroviper  # noqa: F401\n",
     "\n",
-    "    print(\"Using astroviper version\", version(\"astroviper\"))"
+    "except ImportError as exc:\n",
+    "    print(f\"Could not import astroviper: {exc}\")"
    ]
   },
   {
    "cell_type": "markdown",
+   "id": "4",
+   "metadata": {},
+   "source": [
+    "## API\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
    "id": "5",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from astroviper.distributed_applications.image_analysis import moments\n",
+    "\n",
+    "moments?"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "6",
    "metadata": {},
    "source": [
     "## Example 1: Moments of a synthetic spectral-line cube\n",
@@ -146,7 +153,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "6",
+   "id": "7",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -193,7 +200,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "7",
+   "id": "8",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -213,7 +220,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "8",
+   "id": "9",
    "metadata": {},
    "source": [
     "### Inspect the output\n",
@@ -226,7 +233,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "9",
+   "id": "10",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -242,7 +249,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "10",
+   "id": "11",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -266,7 +273,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "11",
+   "id": "12",
    "metadata": {},
    "source": [
     "The `weighted_coord` map recovers the linear drift of the line center along `l`\n",
@@ -283,7 +290,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "12",
+   "id": "13",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -300,7 +307,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "13",
+   "id": "14",
    "metadata": {},
    "source": [
     "---\n",
@@ -324,12 +331,21 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python 3",
+   "display_name": "Python 3 (ipykernel)",
    "language": "python",
    "name": "python3"
   },
   "language_info": {
-   "name": "python"
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.13.7"
   }
  },
  "nbformat": 4,

--- a/docs/distributed_applications_tutorials/image_analysis/multi_gaussian2d_fit.ipynb
+++ b/docs/distributed_applications_tutorials/image_analysis/multi_gaussian2d_fit.ipynb
@@ -7,6 +7,8 @@
    "source": [
     "# Multi-Component 2-D Gaussian Fitting — Tutorial\n",
     "\n",
+    "[Colab Link](https://colab.research.google.com/github/casangi/astroviper/blob/main/docs/distributed_applications_tutorials/image_analysis/multi_gaussian2d_fit.ipynb)\n",
+    "\n",
     "Dave Mehringer, 2026 March\n",
     "\n",
     "This notebook demonstrates the major features of:\n",
@@ -32,13 +34,44 @@
    "id": "1",
    "metadata": {},
    "source": [
-    "## Imports & Utilities"
+    "## Install AstroVIPER\n",
+    "\n",
+    "Skip this cell if you don't want to install the latest version of AstroVIPER."
    ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
    "id": "2",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import os\n",
+    "from importlib.metadata import version\n",
+    "\n",
+    "try:\n",
+    "    os.system(\"pip install --upgrade astroviper[all]\")\n",
+    "\n",
+    "    import astroviper  # noqa: F401 -- availability probe for the pip-install fallback\n",
+    "\n",
+    "    print(\"Using astroviper version\", version(\"astroviper\"))\n",
+    "\n",
+    "except ImportError as exc:\n",
+    "    print(f\"Could not import astroviper: {exc}\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "3",
+   "metadata": {},
+   "source": [
+    "## Imports & Utilities"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "4",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -88,7 +121,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "3",
+   "id": "5",
    "metadata": {},
    "source": [
     "### Utility: synthetic Gaussian scenes\n",
@@ -98,7 +131,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "4",
+   "id": "6",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -186,7 +219,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "5",
+   "id": "7",
    "metadata": {},
    "source": [
     "### Get array min/max"
@@ -195,7 +228,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "6",
+   "id": "8",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -254,7 +287,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "7",
+   "id": "9",
    "metadata": {},
    "source": [
     "### Format value and associated error for pretty printing"
@@ -263,7 +296,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "8",
+   "id": "10",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -315,7 +348,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "9",
+   "id": "11",
    "metadata": {},
    "source": [
     "### Summarize fit solution"
@@ -324,7 +357,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "10",
+   "id": "12",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -359,7 +392,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "11",
+   "id": "13",
    "metadata": {},
    "source": [
     "## Getting your feet wet. Just supplying the data and the number of desired components to be fit.\n",
@@ -386,7 +419,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "12",
+   "id": "14",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -414,7 +447,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "13",
+   "id": "15",
    "metadata": {},
    "source": [
     "Plot the model."
@@ -423,7 +456,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "14",
+   "id": "16",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -434,7 +467,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "15",
+   "id": "17",
    "metadata": {},
    "source": [
     "#### Perform the fit\n",
@@ -460,7 +493,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "16",
+   "id": "18",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -470,7 +503,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "17",
+   "id": "19",
    "metadata": {},
    "source": [
     "Display the solution dataset"
@@ -479,7 +512,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "18",
+   "id": "20",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -488,7 +521,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "19",
+   "id": "21",
    "metadata": {},
    "source": [
     "#### Interrogate the residual image and plot the data\n",
@@ -502,7 +535,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "20",
+   "id": "22",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -515,7 +548,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "21",
+   "id": "23",
    "metadata": {},
    "source": [
     "We can plot data and the residual side by side using the plot_components() function. The overlaid ellipse represents the fit FWHM of the associated component."
@@ -524,7 +557,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "22",
+   "id": "24",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -539,7 +572,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "23",
+   "id": "25",
    "metadata": {},
    "source": [
     "### Two Gaussians in noiseless image\n",
@@ -551,7 +584,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "24",
+   "id": "26",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -572,7 +605,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "25",
+   "id": "27",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -584,28 +617,10 @@
   },
   {
    "cell_type": "markdown",
-   "id": "26",
-   "metadata": {},
-   "source": [
-    "Display the solution dataset"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "27",
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "fit_2g"
-   ]
-  },
-  {
-   "cell_type": "markdown",
    "id": "28",
    "metadata": {},
    "source": [
-    "The min/max residual values should be very small."
+    "Display the solution dataset"
    ]
   },
   {
@@ -615,12 +630,30 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "print(\"residual min, max: \", minmax(fit_2g[\"residual\"]))"
+    "fit_2g"
    ]
   },
   {
    "cell_type": "markdown",
    "id": "30",
+   "metadata": {},
+   "source": [
+    "The min/max residual values should be very small."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "31",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "print(\"residual min, max: \", minmax(fit_2g[\"residual\"]))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "32",
    "metadata": {},
    "source": [
     "Plot the data and the residual image"
@@ -629,7 +662,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "31",
+   "id": "33",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -644,7 +677,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "32",
+   "id": "34",
    "metadata": {},
    "source": [
     "### Fitting with noise\n",
@@ -655,7 +688,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "33",
+   "id": "35",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -678,7 +711,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "34",
+   "id": "36",
    "metadata": {},
    "source": [
     "Perform the fit and summarize the results"
@@ -687,7 +720,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "35",
+   "id": "37",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -698,28 +731,10 @@
   },
   {
    "cell_type": "markdown",
-   "id": "36",
-   "metadata": {},
-   "source": [
-    "Display the solution dataset"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "37",
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "fit_2g_noise"
-   ]
-  },
-  {
-   "cell_type": "markdown",
    "id": "38",
    "metadata": {},
    "source": [
-    "Display the minium and maximum residual pixel values. They reflect the noise."
+    "Display the solution dataset"
    ]
   },
   {
@@ -729,12 +744,30 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "print(\"residual min, max: \", minmax(fit_2g_noise[\"residual\"]))"
+    "fit_2g_noise"
    ]
   },
   {
    "cell_type": "markdown",
    "id": "40",
+   "metadata": {},
+   "source": [
+    "Display the minium and maximum residual pixel values. They reflect the noise."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "41",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "print(\"residual min, max: \", minmax(fit_2g_noise[\"residual\"]))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "42",
    "metadata": {},
    "source": [
     "Plot the data and residual image"
@@ -743,7 +776,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "41",
+   "id": "43",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -758,7 +791,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "42",
+   "id": "44",
    "metadata": {},
    "source": [
     "### Fitting over multiple planes\n",
@@ -769,7 +802,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "43",
+   "id": "45",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -794,29 +827,10 @@
   },
   {
    "cell_type": "markdown",
-   "id": "44",
-   "metadata": {},
-   "source": [
-    "Fit and summarize the solution."
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "45",
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "fit_2p = fit_multi_gaussian2d(data_2p, n_components=2)\n",
-    "summarize_fit(comp_2p, fit_2p)"
-   ]
-  },
-  {
-   "cell_type": "markdown",
    "id": "46",
    "metadata": {},
    "source": [
-    "Display the solution dataset"
+    "Fit and summarize the solution."
    ]
   },
   {
@@ -826,12 +840,31 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "fit_2p"
+    "fit_2p = fit_multi_gaussian2d(data_2p, n_components=2)\n",
+    "summarize_fit(comp_2p, fit_2p)"
    ]
   },
   {
    "cell_type": "markdown",
    "id": "48",
+   "metadata": {},
+   "source": [
+    "Display the solution dataset"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "49",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "fit_2p"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "50",
    "metadata": {},
    "source": [
     "Plot both planes using the **indexer** param to indicate which plane to plot."
@@ -840,7 +873,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "49",
+   "id": "51",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -866,7 +899,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "50",
+   "id": "52",
    "metadata": {},
    "source": [
     "## Threshold masking\n",
@@ -876,7 +909,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "51",
+   "id": "53",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -911,7 +944,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "52",
+   "id": "54",
    "metadata": {},
    "source": [
     "Display dataset"
@@ -920,7 +953,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "53",
+   "id": "55",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -929,7 +962,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "54",
+   "id": "56",
    "metadata": {},
    "source": [
     "## Formats for initial guesses\n",
@@ -945,7 +978,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "55",
+   "id": "57",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -988,7 +1021,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "56",
+   "id": "58",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1048,7 +1081,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "57",
+   "id": "59",
    "metadata": {},
    "source": [
     "### Angle conventions for initial guesses: `\"math\"`, `\"pa\"`, `\"auto\"`\n",
@@ -1070,7 +1103,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "58",
+   "id": "60",
    "metadata": {},
    "source": [
     "## Mask-aware 2D Multi-Gaussian Fitting\n",
@@ -1087,7 +1120,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "59",
+   "id": "61",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1227,7 +1260,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "60",
+   "id": "62",
    "metadata": {},
    "source": [
     "### Baseline: no mask\n",
@@ -1237,7 +1270,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "61",
+   "id": "63",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1266,7 +1299,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "62",
+   "id": "64",
    "metadata": {},
    "source": [
     "### Boolean mask: exclude a bright region\n",
@@ -1276,7 +1309,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "63",
+   "id": "65",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1308,7 +1341,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "64",
+   "id": "66",
    "metadata": {},
    "source": [
     "### OTF string mask (delegates to `selection.select_mask`)\n",
@@ -1318,7 +1351,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "65",
+   "id": "67",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1350,7 +1383,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "66",
+   "id": "68",
    "metadata": {},
    "source": [
     "#### `mask` also accepts a boolean array"
@@ -1359,7 +1392,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "67",
+   "id": "69",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1371,7 +1404,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "68",
+   "id": "70",
    "metadata": {},
    "source": [
     "Now run the fitter using the boolean array just created."
@@ -1380,7 +1413,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "69",
+   "id": "71",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1406,7 +1439,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "70",
+   "id": "72",
    "metadata": {},
    "source": [
     "#### Comparison showing CRTF and bool mask give identical results"
@@ -1415,7 +1448,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "71",
+   "id": "73",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1473,7 +1506,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "72",
+   "id": "74",
    "metadata": {},
    "source": [
     "### Broadcast a `(x, y)` mask across a stacked cube\n",
@@ -1483,7 +1516,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "73",
+   "id": "75",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1521,7 +1554,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "74",
+   "id": "76",
    "metadata": {},
    "source": [
     "### Combine mask with thresholds\n",
@@ -1532,7 +1565,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "75",
+   "id": "77",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1556,7 +1589,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "76",
+   "id": "78",
    "metadata": {},
    "source": [
     "### Error handling: empty effective mask\n",
@@ -1566,7 +1599,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "77",
+   "id": "79",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1586,7 +1619,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "78",
+   "id": "80",
    "metadata": {},
    "source": [
     "## Bounds and fixing parameters\n",
@@ -1611,7 +1644,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "79",
+   "id": "81",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1636,7 +1669,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "80",
+   "id": "82",
    "metadata": {},
    "source": [
     "Keep component 1's major-axis FWHM and minor-axis FWHM in a narrow physically \n",
@@ -1648,7 +1681,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "81",
+   "id": "83",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1679,7 +1712,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "82",
+   "id": "84",
    "metadata": {},
    "source": [
     "The synthetic scene was generated with zero background offset, so we can \n",
@@ -1690,7 +1723,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "83",
+   "id": "85",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1729,7 +1762,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "84",
+   "id": "86",
    "metadata": {},
    "source": [
     "## Return model and residual\n",
@@ -1754,7 +1787,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "85",
+   "id": "87",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1784,7 +1817,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "86",
+   "id": "88",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1813,7 +1846,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "87",
+   "id": "89",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1822,7 +1855,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "88",
+   "id": "90",
    "metadata": {},
    "source": [
     "Plot the data, residual, and model"
@@ -1831,7 +1864,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "89",
+   "id": "91",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1843,7 +1876,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "90",
+   "id": "92",
    "metadata": {},
    "source": [
     "## Vectorized fitting over extra dims\n",
@@ -1857,7 +1890,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "91",
+   "id": "93",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1879,7 +1912,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "92",
+   "id": "94",
    "metadata": {},
    "source": [
     "## Dask-backed arrays\n",
@@ -1891,7 +1924,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "93",
+   "id": "95",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1916,7 +1949,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "94",
+   "id": "96",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1977,7 +2010,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "95",
+   "id": "97",
    "metadata": {},
    "source": [
     "## World coordinates of centroids\n",
@@ -1987,7 +2020,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "96",
+   "id": "98",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1997,7 +2030,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "97",
+   "id": "99",
    "metadata": {},
    "source": [
     "## Error handling & tips\n",
@@ -2025,7 +2058,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.13.12"
+   "version": "3.13.7"
   }
  },
  "nbformat": 4,

--- a/docs/distributed_applications_tutorials/image_analysis/xradio_image_selection.ipynb
+++ b/docs/distributed_applications_tutorials/image_analysis/xradio_image_selection.ipynb
@@ -7,6 +7,8 @@
    "source": [
     "# Image Region Selection for xradio Images\n",
     "\n",
+    "[Colab Link](https://colab.research.google.com/github/casangi/astroviper/blob/main/docs/distributed_applications_tutorials/image_analysis/xradio_image_selection.ipynb)\n",
+    "\n",
     "This notebook demonstrates the extended CRTF selection features available when working with\n",
     "xradio-format sky images — five-dimensional DataArrays with dims\n",
     "`(time, frequency, polarization, l, m)` and the corresponding named coordinates.\n",
@@ -26,9 +28,40 @@
    ]
   },
   {
+   "cell_type": "markdown",
+   "id": "1",
+   "metadata": {},
+   "source": [
+    "## Install AstroVIPER\n",
+    "\n",
+    "Skip this cell if you don't want to install the latest version of AstroVIPER."
+   ]
+  },
+  {
    "cell_type": "code",
    "execution_count": null,
-   "id": "1",
+   "id": "2",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import os\n",
+    "from importlib.metadata import version\n",
+    "\n",
+    "try:\n",
+    "    os.system(\"pip install --upgrade astroviper[all]\")\n",
+    "\n",
+    "    import astroviper  # noqa: F401 -- availability probe for the pip-install fallback\n",
+    "\n",
+    "    print(\"Using astroviper version\", version(\"astroviper\"))\n",
+    "\n",
+    "except ImportError as exc:\n",
+    "    print(f\"Could not import astroviper: {exc}\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "3",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -45,7 +78,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "2",
+   "id": "4",
    "metadata": {},
    "source": [
     "## Building a representative sky DataArray\n",
@@ -62,7 +95,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "3",
+   "id": "5",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -184,7 +217,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "4",
+   "id": "6",
    "metadata": {},
    "source": [
     "The `l` and `m` coordinates carry the physical angular scale.  We will always express\n",
@@ -210,7 +243,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "5",
+   "id": "7",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -636,7 +669,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "6",
+   "id": "8",
    "metadata": {},
    "source": [
     "<a id=\"lm-mode-shapes\"></a>\n",
@@ -659,7 +692,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "7",
+   "id": "9",
    "metadata": {},
    "source": [
     "### circle\n",
@@ -674,7 +707,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "8",
+   "id": "10",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -691,7 +724,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "9",
+   "id": "11",
    "metadata": {},
    "source": [
     "### annulus\n",
@@ -705,7 +738,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "10",
+   "id": "12",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -722,7 +755,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "11",
+   "id": "13",
    "metadata": {},
    "source": [
     "### centerbox\n",
@@ -739,7 +772,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "12",
+   "id": "14",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -757,7 +790,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "13",
+   "id": "15",
    "metadata": {},
    "source": [
     "### box\n",
@@ -773,7 +806,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "14",
+   "id": "16",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -789,7 +822,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "15",
+   "id": "17",
    "metadata": {},
    "source": [
     "### rotbox — rotated rectangle\n",
@@ -811,7 +844,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "16",
+   "id": "18",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -827,7 +860,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "17",
+   "id": "19",
    "metadata": {},
    "source": [
     "### ellipse\n",
@@ -843,7 +876,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "18",
+   "id": "20",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -859,7 +892,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "19",
+   "id": "21",
    "metadata": {},
    "source": [
     "### poly — arbitrary polygon\n",
@@ -875,7 +908,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "20",
+   "id": "22",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -892,7 +925,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "21",
+   "id": "23",
    "metadata": {},
    "source": [
     "### arcmin units\n",
@@ -907,7 +940,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "22",
+   "id": "24",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -925,7 +958,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "23",
+   "id": "25",
    "metadata": {},
    "source": [
     "### Combining lm-mode shapes\n",
@@ -939,7 +972,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "24",
+   "id": "26",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -956,7 +989,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "25",
+   "id": "27",
    "metadata": {},
    "source": [
     "<a id=\"world-mode-shapes\"></a>\n",
@@ -985,7 +1018,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "26",
+   "id": "28",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1000,7 +1033,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "27",
+   "id": "29",
    "metadata": {},
    "source": [
     "### circle\n",
@@ -1014,7 +1047,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "28",
+   "id": "30",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1026,7 +1059,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "29",
+   "id": "31",
    "metadata": {},
    "source": [
     "### centerbox\n",
@@ -1040,7 +1073,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "30",
+   "id": "32",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1052,7 +1085,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "31",
+   "id": "33",
    "metadata": {},
    "source": [
     "### box — decimal degrees with coordsys=world\n",
@@ -1069,7 +1102,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "32",
+   "id": "34",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1081,7 +1114,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "33",
+   "id": "35",
    "metadata": {},
    "source": [
     "### rotbox — rotated box\n",
@@ -1095,7 +1128,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "34",
+   "id": "36",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1109,7 +1142,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "35",
+   "id": "37",
    "metadata": {},
    "source": [
     "### ellipse\n",
@@ -1122,7 +1155,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "36",
+   "id": "38",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1138,7 +1171,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "37",
+   "id": "39",
    "metadata": {},
    "source": [
     "### poly — arbitrary polygon with decimal degrees\n",
@@ -1153,7 +1186,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "38",
+   "id": "40",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1171,7 +1204,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "39",
+   "id": "41",
    "metadata": {},
    "source": [
     "<a id=\"range-selection\"></a>\n",
@@ -1200,7 +1233,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "40",
+   "id": "42",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1222,7 +1255,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "41",
+   "id": "43",
    "metadata": {},
    "source": [
     "### Channel range\n",
@@ -1233,7 +1266,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "42",
+   "id": "44",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1262,7 +1295,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "43",
+   "id": "45",
    "metadata": {},
    "source": [
     "### Frequency range\n",
@@ -1274,7 +1307,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "44",
+   "id": "46",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1310,7 +1343,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "45",
+   "id": "47",
    "metadata": {},
    "source": [
     "### Velocity range\n",
@@ -1322,7 +1355,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "46",
+   "id": "48",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1356,7 +1389,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "47",
+   "id": "49",
    "metadata": {},
    "source": [
     "### Out-of-range spec → all-False mask\n",
@@ -1367,7 +1400,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "48",
+   "id": "50",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1378,7 +1411,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "49",
+   "id": "51",
    "metadata": {},
    "source": [
     "<a id=\"corr-selection\"></a>\n",
@@ -1394,7 +1427,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "50",
+   "id": "52",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1405,7 +1438,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "51",
+   "id": "53",
    "metadata": {},
    "source": [
     "### Select a single polarization\n",
@@ -1416,7 +1449,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "52",
+   "id": "54",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1443,7 +1476,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "53",
+   "id": "55",
    "metadata": {},
    "source": [
     "### Select multiple polarizations\n",
@@ -1454,7 +1487,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "54",
+   "id": "56",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1485,7 +1518,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "55",
+   "id": "57",
    "metadata": {},
    "source": [
     "<a id=\"time-selection\"></a>\n",
@@ -1510,7 +1543,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "56",
+   "id": "58",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1521,7 +1554,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "57",
+   "id": "59",
    "metadata": {},
    "source": [
     "### MJD range\n",
@@ -1532,7 +1565,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "58",
+   "id": "60",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1555,7 +1588,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "59",
+   "id": "61",
    "metadata": {},
    "source": [
     "### ISO format\n",
@@ -1567,7 +1600,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "60",
+   "id": "62",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1594,7 +1627,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "61",
+   "id": "63",
    "metadata": {},
    "source": [
     "### Non-overlapping range → all-False mask\n",
@@ -1607,7 +1640,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "62",
+   "id": "64",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1619,7 +1652,7 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "zinc",
+   "display_name": "Python 3 (ipykernel)",
    "language": "python",
    "name": "python3"
   },
@@ -1633,7 +1666,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.13.0"
+   "version": "3.13.7"
   }
  },
  "nbformat": 4,

--- a/docs/distributed_applications_tutorials/imaging/astroviper_tutorial_fft.ipynb
+++ b/docs/distributed_applications_tutorials/imaging/astroviper_tutorial_fft.ipynb
@@ -7,7 +7,7 @@
    "source": [
     "# FFT tutorial\n",
     "\n",
-    "[Colab Link](https://colab.research.google.com/github/casangi/astroviper/blob/main/docs/distributed_applications_tutorials/imaging/atsroviper_tutorial_fft.ipynb)"
+    "[Colab Link](https://colab.research.google.com/github/casangi/astroviper/blob/main/docs/distributed_applications_tutorials/imaging/astroviper_tutorial_fft.ipynb)"
    ]
   },
   {

--- a/docs/distributed_applications_tutorials/imaging/atsroviper_tutorial_fft.ipynb
+++ b/docs/distributed_applications_tutorials/imaging/atsroviper_tutorial_fft.ipynb
@@ -1,9 +1,50 @@
 {
  "cells": [
   {
+   "cell_type": "markdown",
+   "id": "0",
+   "metadata": {},
+   "source": [
+    "# FFT tutorial\n",
+    "\n",
+    "[Colab Link](https://colab.research.google.com/github/casangi/astroviper/blob/main/docs/distributed_applications_tutorials/imaging/atsroviper_tutorial_fft.ipynb)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "1",
+   "metadata": {},
+   "source": [
+    "## Install AstroVIPER\n",
+    "\n",
+    "Skip this cell if you don't want to install the latest version of AstroVIPER."
+   ]
+  },
+  {
    "cell_type": "code",
    "execution_count": null,
-   "id": "0",
+   "id": "2",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import os\n",
+    "from importlib.metadata import version\n",
+    "\n",
+    "try:\n",
+    "    os.system(\"pip install --upgrade astroviper[all]\")\n",
+    "\n",
+    "    import astroviper  # noqa: F401 -- availability probe for the pip-install fallback\n",
+    "\n",
+    "    print(\"Using astroviper version\", version(\"astroviper\"))\n",
+    "\n",
+    "except ImportError as exc:\n",
+    "    print(f\"Could not import astroviper: {exc}\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "3",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -18,7 +59,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "1",
+   "id": "4",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -43,7 +84,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "2",
+   "id": "5",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -62,7 +103,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "3",
+   "id": "6",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -80,7 +121,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "4",
+   "id": "7",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -99,7 +140,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "5",
+   "id": "8",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -116,7 +157,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "6",
+   "id": "9",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -176,7 +217,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "7",
+   "id": "10",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -186,7 +227,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "8",
+   "id": "11",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -196,7 +237,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "9",
+   "id": "12",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -206,7 +247,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "10",
+   "id": "13",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -216,7 +257,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "11",
+   "id": "14",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -228,7 +269,7 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "timg",
+   "display_name": "Python 3 (ipykernel)",
    "language": "python",
    "name": "python3"
   },

--- a/docs/distributed_applications_tutorials/imaging/feather_tutorial.ipynb
+++ b/docs/distributed_applications_tutorials/imaging/feather_tutorial.ipynb
@@ -25,15 +25,48 @@
     "tags": []
    },
    "source": [
+    "[Colab Link](https://colab.research.google.com/github/casangi/astroviper/blob/main/docs/distributed_applications_tutorials/imaging/feather_tutorial.ipynb)\n",
+    "\n",
     "**Prerequisite:** run `docs/tutorials/feather_tutorial_create_initial_images.ipynb` first.\n",
     "\n",
     "This tutorial assumes those generated products exist (or can be downloaded by name)."
    ]
   },
   {
+   "cell_type": "markdown",
+   "id": "2",
+   "metadata": {},
+   "source": [
+    "## Install AstroVIPER\n",
+    "\n",
+    "Skip this cell if you don't want to install the latest version of AstroVIPER."
+   ]
+  },
+  {
    "cell_type": "code",
    "execution_count": null,
-   "id": "2",
+   "id": "3",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import os\n",
+    "from importlib.metadata import version\n",
+    "\n",
+    "try:\n",
+    "    os.system(\"pip install --upgrade astroviper[all]\")\n",
+    "\n",
+    "    import astroviper  # noqa: F401 -- availability probe for the pip-install fallback\n",
+    "\n",
+    "    print(\"Using astroviper version\", version(\"astroviper\"))\n",
+    "\n",
+    "except ImportError as exc:\n",
+    "    print(f\"Could not import astroviper: {exc}\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "4",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -49,7 +82,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "3",
+   "id": "5",
    "metadata": {
     "editable": true,
     "slideshow": {
@@ -79,7 +112,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "4",
+   "id": "6",
    "metadata": {
     "editable": true,
     "slideshow": {
@@ -121,7 +154,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "5",
+   "id": "7",
    "metadata": {
     "editable": true,
     "slideshow": {
@@ -147,7 +180,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "6",
+   "id": "8",
    "metadata": {
     "editable": true,
     "slideshow": {
@@ -169,7 +202,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "7",
+   "id": "9",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -197,7 +230,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "8",
+   "id": "10",
    "metadata": {
     "editable": true,
     "slideshow": {
@@ -336,7 +369,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "9",
+   "id": "11",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -346,7 +379,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "10",
+   "id": "12",
    "metadata": {
     "editable": true,
     "slideshow": {
@@ -361,7 +394,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "11",
+   "id": "13",
    "metadata": {},
    "source": [
     "# MODEL GENERATION SCRIPT\n",
@@ -374,7 +407,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "12",
+   "id": "14",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -682,7 +715,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "13",
+   "id": "15",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -692,7 +725,7 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "zinc",
+   "display_name": "Python 3 (ipykernel)",
    "language": "python",
    "name": "python3"
   },
@@ -706,7 +739,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.13.0"
+   "version": "3.13.7"
   }
  },
  "nbformat": 4,

--- a/docs/distributed_applications_tutorials/imaging/feather_tutorial_create_initial_images.ipynb
+++ b/docs/distributed_applications_tutorials/imaging/feather_tutorial_create_initial_images.ipynb
@@ -5,13 +5,54 @@
    "id": "0",
    "metadata": {},
    "source": [
+    "# Feather tutorial (create initial images)\n",
+    "\n",
+    "[Colab Link](https://colab.research.google.com/github/casangi/astroviper/blob/main/docs/distributed_applications_tutorials/imaging/feather_tutorial_create_initial_images.ipynb)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "1",
+   "metadata": {},
+   "source": [
+    "## Install AstroVIPER\n",
+    "\n",
+    "Skip this cell if you don't want to install the latest version of AstroVIPER."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "2",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import os\n",
+    "from importlib.metadata import version\n",
+    "\n",
+    "try:\n",
+    "    os.system(\"pip install --upgrade astroviper[all]\")\n",
+    "\n",
+    "    import astroviper  # noqa: F401 -- availability probe for the pip-install fallback\n",
+    "\n",
+    "    print(\"Using astroviper version\", version(\"astroviper\"))\n",
+    "\n",
+    "except ImportError as exc:\n",
+    "    print(f\"Could not import astroviper: {exc}\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "3",
+   "metadata": {},
+   "source": [
     "<h1>Create initial images to be used in feather tutorial</h1>"
    ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "1",
+   "id": "4",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -25,7 +66,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "2",
+   "id": "5",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -39,7 +80,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "3",
+   "id": "6",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -53,7 +94,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "4",
+   "id": "7",
    "metadata": {},
    "source": [
     "<h2>Inputs to be specified by user</h2>"
@@ -62,7 +103,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "5",
+   "id": "8",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -78,7 +119,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "6",
+   "id": "9",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -101,7 +142,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "7",
+   "id": "10",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -126,7 +167,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "8",
+   "id": "11",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -141,7 +182,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "9",
+   "id": "12",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -166,7 +207,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "10",
+   "id": "13",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -187,7 +228,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "11",
+   "id": "14",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -218,7 +259,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "12",
+   "id": "15",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -247,7 +288,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "13",
+   "id": "16",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -257,7 +298,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "14",
+   "id": "17",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -269,7 +310,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "15",
+   "id": "18",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -292,7 +333,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "16",
+   "id": "19",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -303,7 +344,7 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "timg",
+   "display_name": "Python 3 (ipykernel)",
    "language": "python",
    "name": "python3"
   },

--- a/docs/distributed_applications_tutorials/imaging/single_field_cube.ipynb
+++ b/docs/distributed_applications_tutorials/imaging/single_field_cube.ipynb
@@ -7,6 +7,9 @@
    "source": [
     "# Single-Field Cube Imaging with AstroVIPER\n",
     "\n",
+    "[Colab Link](https://colab.research.google.com/github/casangi/astroviper/blob/main/docs/distributed_applications_tutorials/imaging/feather_tutorial.ipynb)\n",
+    "\n",
+    "\n",
     "**AstroVIPER** (Astro **V**isibility and **I**mage **P**arallel **E**xecution **R**eduction)\n",
     "is the *science* package of the VIPER radio-astronomy ecosystem:\n",
     "\n",
@@ -892,7 +895,7 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "zinc",
+   "display_name": "Python 3 (ipykernel)",
    "language": "python",
    "name": "python3"
   },
@@ -906,7 +909,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.13.0"
+   "version": "3.13.7"
   }
  },
  "nbformat": 4,

--- a/docs/distributed_applications_tutorials/model/component_models.ipynb
+++ b/docs/distributed_applications_tutorials/model/component_models.ipynb
@@ -7,6 +7,8 @@
    "source": [
     "# Component Model Notebook\n",
     "\n",
+    "[Colab Link](https://colab.research.google.com/github/casangi/astroviper/blob/main/docs/distributed_applications_tutorials/model/component_models.ipynb)\n",
+    "\n",
     "Common spatial models can be created using functions in the astroviper.distributed.model package. Supported models are\n",
     "* elliptical disk\n",
     "* 2d elliptical gaussian\n",
@@ -23,9 +25,40 @@
    ]
   },
   {
+   "cell_type": "markdown",
+   "id": "1",
+   "metadata": {},
+   "source": [
+    "## Install AstroVIPER\n",
+    "\n",
+    "Skip this cell if you don't want to install the latest version of AstroVIPER."
+   ]
+  },
+  {
    "cell_type": "code",
    "execution_count": null,
-   "id": "1",
+   "id": "2",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import os\n",
+    "from importlib.metadata import version\n",
+    "\n",
+    "try:\n",
+    "    os.system(\"pip install --upgrade astroviper[all]\")\n",
+    "\n",
+    "    import astroviper  # noqa: F401 -- availability probe for the pip-install fallback\n",
+    "\n",
+    "    print(\"Using astroviper version\", version(\"astroviper\"))\n",
+    "\n",
+    "except ImportError as exc:\n",
+    "    print(f\"Could not import astroviper: {exc}\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "3",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -44,7 +77,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "2",
+   "id": "4",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -57,7 +90,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "3",
+   "id": "5",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -70,7 +103,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "4",
+   "id": "6",
    "metadata": {},
    "source": [
     "## Disk\n",
@@ -107,7 +140,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "5",
+   "id": "7",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -125,7 +158,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "6",
+   "id": "8",
    "metadata": {},
    "source": [
     "Here we show the behavior of angle=\"auto\" in a left-handed coordinate system\n",
@@ -136,7 +169,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "7",
+   "id": "9",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -161,7 +194,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "8",
+   "id": "10",
    "metadata": {},
    "source": [
     "Here we force the angle to use the math convention, so it is measured from +x -> +y"
@@ -170,7 +203,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "9",
+   "id": "11",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -191,7 +224,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "10",
+   "id": "12",
    "metadata": {},
    "source": [
     "Similarly, we can force the angle in our first disk, the one with the\n",
@@ -201,7 +234,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "11",
+   "id": "13",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -213,7 +246,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "12",
+   "id": "14",
    "metadata": {},
    "source": [
     "## 2D Gaussian\n",
@@ -226,7 +259,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "13",
+   "id": "15",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -238,7 +271,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "14",
+   "id": "16",
    "metadata": {},
    "source": [
     "## Collection of Point Sources\n",
@@ -251,7 +284,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "15",
+   "id": "17",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -261,7 +294,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "16",
+   "id": "18",
    "metadata": {},
    "source": [
     "### TODO\n",
@@ -286,7 +319,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.12.9"
+   "version": "3.13.7"
   }
  },
  "nbformat": 4,

--- a/docs/processing_functions_tutorials/image_analysis/make_mask.ipynb
+++ b/docs/processing_functions_tutorials/image_analysis/make_mask.ipynb
@@ -7,12 +7,49 @@
    "source": [
     "# Create and Update Mask Demo\n",
     "\n",
-    "[Colab Link](https://colab.research.google.com/github/casangi/astroviper/blob/main/docs/core_tutorials/image_analysis/make_mask.ipynb)\n",
+    "[Colab Link](https://colab.research.google.com/github/casangi/astroviper/blob/main/docs/procesing_functions_tutorials/image_analysis/make_mask.ipynb)\n",
     "\n",
     "This notebook demonstrates how to create and update a mask image using the `make_mask` function. The function takes an xradio image `xarray.Dataset` (`img_xds`) that contains a primary-beam data variable referenced by an `\"image\"` data group in `img_xds.attrs[\"data_groups\"]`, and writes a boolean mask data variable back into the same dataset (in place). The current implementation supports a primary-beam threshold mask for deconvolution; other mask types may be added in the future.\n",
     "\n",
-    "---\n",
+    "---\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "ae93af33-4754-4e04-86f9-18c78c39b6ae",
+   "metadata": {},
+   "source": [
+    "## Install AstroVIPER\n",
     "\n",
+    "Skip this cell if you don't want to install the latest version of AstroVIPER."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "eeb803e7-2354-4a05-924a-6c8532856d61",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import os\n",
+    "from importlib.metadata import version\n",
+    "\n",
+    "try:\n",
+    "    os.system(\"pip install --upgrade astroviper[all]\")\n",
+    "\n",
+    "    import astroviper  # noqa: F401 -- availability probe for the pip-install fallback\n",
+    "\n",
+    "    print(\"Using astroviper version\", version(\"astroviper\"))\n",
+    "\n",
+    "except ImportError as exc:\n",
+    "    print(f\"Could not import astroviper: {exc}\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "b1211c8a-ece1-4adf-89e2-2601400853f5",
+   "metadata": {},
+   "source": [
     "## API"
    ]
   },
@@ -624,7 +661,7 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "zinc",
+   "display_name": "Python 3 (ipykernel)",
    "language": "python",
    "name": "python3"
   },
@@ -638,7 +675,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.13.0"
+   "version": "3.13.7"
   }
  },
  "nbformat": 4,

--- a/docs/processing_functions_tutorials/image_analysis/make_mask.ipynb
+++ b/docs/processing_functions_tutorials/image_analysis/make_mask.ipynb
@@ -16,7 +16,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "ae93af33-4754-4e04-86f9-18c78c39b6ae",
+   "id": "1",
    "metadata": {},
    "source": [
     "## Install AstroVIPER\n",
@@ -27,7 +27,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "eeb803e7-2354-4a05-924a-6c8532856d61",
+   "id": "2",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -47,7 +47,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "b1211c8a-ece1-4adf-89e2-2601400853f5",
+   "id": "3",
    "metadata": {},
    "source": [
     "## API"
@@ -56,7 +56,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "1",
+   "id": "4",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -67,7 +67,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "2",
+   "id": "5",
    "metadata": {},
    "source": [
     "---\n",
@@ -83,7 +83,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "3",
+   "id": "6",
    "metadata": {},
    "source": [
     "## Install AstroVIPER\n",
@@ -94,7 +94,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "4",
+   "id": "7",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -114,7 +114,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "5",
+   "id": "8",
    "metadata": {},
    "source": [
     "## Import additional modules/functions used in this notebook"
@@ -123,7 +123,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "6",
+   "id": "9",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -139,7 +139,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "7",
+   "id": "10",
    "metadata": {},
    "source": [
     "## Generate input images\n",
@@ -155,7 +155,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "8",
+   "id": "11",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -240,7 +240,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "9",
+   "id": "12",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -255,7 +255,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "10",
+   "id": "13",
    "metadata": {},
    "source": [
     "### Generate PB xds @~100GHz"
@@ -264,7 +264,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "11",
+   "id": "14",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -280,7 +280,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "12",
+   "id": "15",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -289,7 +289,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "13",
+   "id": "16",
    "metadata": {},
    "source": [
     "### Generate residual image with an internal mask"
@@ -298,7 +298,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "14",
+   "id": "17",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -315,7 +315,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "15",
+   "id": "18",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -324,7 +324,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "16",
+   "id": "19",
    "metadata": {},
    "source": [
     "### Plot the input data"
@@ -333,7 +333,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "17",
+   "id": "20",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -381,7 +381,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "18",
+   "id": "21",
    "metadata": {},
    "source": [
     "## Example 1: Create a PB threshold-based mask\n",
@@ -391,7 +391,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "19",
+   "id": "22",
    "metadata": {},
    "source": [
     "### Create the mask"
@@ -400,7 +400,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "20",
+   "id": "23",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -410,7 +410,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "21",
+   "id": "24",
    "metadata": {},
    "source": [
     "##### The new boolean mask now lives under the `MASK` data variable on `img_xds`."
@@ -419,7 +419,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "22",
+   "id": "25",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -428,7 +428,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "23",
+   "id": "26",
    "metadata": {},
    "source": [
     "##### The output data group records the mask role plus an audit-trail entry."
@@ -437,7 +437,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "24",
+   "id": "27",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -446,7 +446,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "25",
+   "id": "28",
    "metadata": {},
    "source": [
     "### Plot mask data for confirmation"
@@ -455,7 +455,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "26",
+   "id": "29",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -466,7 +466,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "27",
+   "id": "30",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -476,7 +476,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "28",
+   "id": "31",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -487,7 +487,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "29",
+   "id": "32",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -510,7 +510,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "30",
+   "id": "33",
    "metadata": {},
    "source": [
     "## Example 2: Combining with an existing mask\n",
@@ -523,7 +523,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "31",
+   "id": "34",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -544,7 +544,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "32",
+   "id": "35",
    "metadata": {},
    "source": [
     "### Plot the combined mask"
@@ -553,7 +553,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "33",
+   "id": "36",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -575,7 +575,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "34",
+   "id": "37",
    "metadata": {},
    "source": [
     "## Example 3: Storing the result under a separate output data group\n",
@@ -586,7 +586,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "35",
+   "id": "38",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -601,7 +601,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "36",
+   "id": "39",
    "metadata": {},
    "source": [
     "### Both data groups are now registered, and the new mask is in `MASK_PB`."
@@ -610,7 +610,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "37",
+   "id": "40",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -620,7 +620,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "38",
+   "id": "41",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -629,7 +629,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "39",
+   "id": "42",
    "metadata": {},
    "source": [
     "#### Plot the new mask"
@@ -638,7 +638,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "40",
+   "id": "43",
    "metadata": {},
    "outputs": [],
    "source": [

--- a/docs/processing_functions_tutorials/image_analysis/make_mask.ipynb
+++ b/docs/processing_functions_tutorials/image_analysis/make_mask.ipynb
@@ -86,44 +86,13 @@
    "id": "6",
    "metadata": {},
    "source": [
-    "## Install AstroVIPER\n",
-    "\n",
-    "Skip this cell if you don't want to install the latest version of AstroVIPER."
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "7",
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "import os\n",
-    "from importlib.metadata import version\n",
-    "\n",
-    "try:\n",
-    "    os.system(\"pip install --upgrade astroviper\")\n",
-    "\n",
-    "    import astroviper  # noqa: F401 -- availability probe for the pip-install fallback\n",
-    "\n",
-    "    print(\"Using astroviper version\", version(\"astroviper\"))\n",
-    "\n",
-    "except ImportError as exc:\n",
-    "    print(f\"Could not import astroviper: {exc}\")"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "id": "8",
-   "metadata": {},
-   "source": [
     "## Import additional modules/functions used in this notebook"
    ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "9",
+   "id": "7",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -139,7 +108,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "10",
+   "id": "8",
    "metadata": {},
    "source": [
     "## Generate input images\n",
@@ -155,7 +124,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "11",
+   "id": "9",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -240,7 +209,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "12",
+   "id": "10",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -255,7 +224,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "13",
+   "id": "11",
    "metadata": {},
    "source": [
     "### Generate PB xds @~100GHz"
@@ -264,7 +233,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "14",
+   "id": "12",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -280,7 +249,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "15",
+   "id": "13",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -289,7 +258,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "16",
+   "id": "14",
    "metadata": {},
    "source": [
     "### Generate residual image with an internal mask"
@@ -298,7 +267,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "17",
+   "id": "15",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -315,7 +284,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "18",
+   "id": "16",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -324,7 +293,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "19",
+   "id": "17",
    "metadata": {},
    "source": [
     "### Plot the input data"
@@ -333,7 +302,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "20",
+   "id": "18",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -381,7 +350,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "21",
+   "id": "19",
    "metadata": {},
    "source": [
     "## Example 1: Create a PB threshold-based mask\n",
@@ -391,7 +360,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "22",
+   "id": "20",
    "metadata": {},
    "source": [
     "### Create the mask"
@@ -400,7 +369,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "23",
+   "id": "21",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -410,10 +379,28 @@
   },
   {
    "cell_type": "markdown",
-   "id": "24",
+   "id": "22",
    "metadata": {},
    "source": [
     "##### The new boolean mask now lives under the `MASK` data variable on `img_xds`."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "23",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "img_xds"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "24",
+   "metadata": {},
+   "source": [
+    "##### The output data group records the mask role plus an audit-trail entry."
    ]
   },
   {
@@ -423,30 +410,12 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "img_xds"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "id": "26",
-   "metadata": {},
-   "source": [
-    "##### The output data group records the mask role plus an audit-trail entry."
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "27",
-   "metadata": {},
-   "outputs": [],
-   "source": [
     "img_xds.attrs[\"data_groups\"]"
    ]
   },
   {
    "cell_type": "markdown",
-   "id": "28",
+   "id": "26",
    "metadata": {},
    "source": [
     "### Plot mask data for confirmation"
@@ -455,7 +424,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "29",
+   "id": "27",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -466,7 +435,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "30",
+   "id": "28",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -476,7 +445,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "31",
+   "id": "29",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -487,7 +456,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "32",
+   "id": "30",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -510,7 +479,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "33",
+   "id": "31",
    "metadata": {},
    "source": [
     "## Example 2: Combining with an existing mask\n",
@@ -523,7 +492,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "34",
+   "id": "32",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -544,7 +513,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "35",
+   "id": "33",
    "metadata": {},
    "source": [
     "### Plot the combined mask"
@@ -553,7 +522,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "36",
+   "id": "34",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -575,7 +544,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "37",
+   "id": "35",
    "metadata": {},
    "source": [
     "## Example 3: Storing the result under a separate output data group\n",
@@ -586,7 +555,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "38",
+   "id": "36",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -601,7 +570,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "39",
+   "id": "37",
    "metadata": {},
    "source": [
     "### Both data groups are now registered, and the new mask is in `MASK_PB`."
@@ -610,7 +579,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "40",
+   "id": "38",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -620,7 +589,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "41",
+   "id": "39",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -629,7 +598,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "42",
+   "id": "40",
    "metadata": {},
    "source": [
     "#### Plot the new mask"
@@ -638,7 +607,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "43",
+   "id": "41",
    "metadata": {},
    "outputs": [],
    "source": [

--- a/docs/processing_functions_tutorials/image_analysis/psf_fitting.ipynb
+++ b/docs/processing_functions_tutorials/image_analysis/psf_fitting.ipynb
@@ -25,37 +25,6 @@
    "id": "2",
    "metadata": {},
    "source": [
-    "## Install AstroVIPER\n",
-    "\n",
-    "Skip this cell if you don't want to install the latest version of AstroVIPER."
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "3",
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "import os\n",
-    "from importlib.metadata import version\n",
-    "\n",
-    "try:\n",
-    "    os.system(\"pip install --upgrade astroviper[all]\")\n",
-    "\n",
-    "    import astroviper  # noqa: F401 -- availability probe for the pip-install fallback\n",
-    "\n",
-    "    print(\"Using astroviper version\", version(\"astroviper\"))\n",
-    "\n",
-    "except ImportError as exc:\n",
-    "    print(f\"Could not import astroviper: {exc}\")"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "id": "4",
-   "metadata": {},
-   "source": [
     "## Pseudo Code\n",
     "\n",
     "xds_image\n",
@@ -81,6 +50,37 @@
     "       MAX_SIDELOBE_*    = max_sidelobe\n",
     "   return xds_new\n",
     "```"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "3",
+   "metadata": {},
+   "source": [
+    "## Install AstroVIPER\n",
+    "\n",
+    "Skip this cell if you don't want to install the latest version of AstroVIPER."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "4",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import os\n",
+    "from importlib.metadata import version\n",
+    "\n",
+    "try:\n",
+    "    os.system(\"pip install --upgrade astroviper[all]\")\n",
+    "\n",
+    "    import astroviper  # noqa: F401 -- availability probe for the pip-install fallback\n",
+    "\n",
+    "    print(\"Using astroviper version\", version(\"astroviper\"))\n",
+    "\n",
+    "except ImportError as exc:\n",
+    "    print(f\"Could not import astroviper: {exc}\")"
    ]
   },
   {
@@ -129,45 +129,12 @@
    "id": "8",
    "metadata": {},
    "source": [
-    "## Install AstroVIPER\n",
-    "\n",
-    "This tutorial runs against an already-installed astroviper (for example an editable development checkout). Run the cell below only if you want to install or upgrade astroviper from PyPI."
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "9",
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "from importlib.metadata import version\n",
-    "\n",
-    "# This tutorial runs against an already-installed astroviper (e.g. an editable\n",
-    "# development checkout). To install/upgrade from PyPI instead, uncomment the\n",
-    "# two os.system lines below.\n",
-    "# import os\n",
-    "# os.system(\"pip install --upgrade astroviper\")\n",
-    "# os.system(\"pip install python-casacore\")\n",
-    "try:\n",
-    "    import astroviper  # noqa: F401 -- availability probe\n",
-    "\n",
-    "    print(\"Using astroviper version\", version(\"astroviper\"))\n",
-    "except ImportError as exc:\n",
-    "    print(f\"Could not import astroviper: {exc}\")"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "id": "10",
-   "metadata": {},
-   "source": [
     "## Download Data"
    ]
   },
   {
    "cell_type": "markdown",
-   "id": "11",
+   "id": "9",
    "metadata": {},
    "source": [
     "Download the test CASA PSF image and convert to the XRADIO image"
@@ -176,7 +143,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "12",
+   "id": "10",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -189,7 +156,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "13",
+   "id": "11",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -200,7 +167,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "14",
+   "id": "12",
    "metadata": {},
    "source": [
     "## Import the data and run PSF gaussian fit "
@@ -208,7 +175,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "15",
+   "id": "13",
    "metadata": {},
    "source": [
     "### Import the CASA image to an XRADIO image data"
@@ -217,7 +184,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "16",
+   "id": "14",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -241,7 +208,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "17",
+   "id": "15",
    "metadata": {},
    "source": [
     "### Examine data content"
@@ -250,7 +217,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "18",
+   "id": "16",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -260,7 +227,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "19",
+   "id": "17",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -269,7 +236,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "20",
+   "id": "18",
    "metadata": {},
    "source": [
     "### Run gaussian fit on the PSF image"
@@ -277,7 +244,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "21",
+   "id": "19",
    "metadata": {},
    "source": [
     "The `point_spread_function_gaussian_fit` function returns a copy of the dataset with two new data variables, registered under a new `test_psf_fit` data group:\n",
@@ -291,7 +258,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "22",
+   "id": "20",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -316,7 +283,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "23",
+   "id": "21",
    "metadata": {},
    "source": [
     "##　Results"
@@ -325,7 +292,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "24",
+   "id": "22",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -339,7 +306,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "25",
+   "id": "23",
    "metadata": {},
    "source": [
     "### Plot the input image with the original CASA beam stored in the image for reference"
@@ -348,7 +315,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "26",
+   "id": "24",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -359,7 +326,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "27",
+   "id": "25",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -397,7 +364,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "28",
+   "id": "26",
    "metadata": {},
    "source": [
     "### Compare the fitting result with one provided in the input image"
@@ -406,7 +373,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "29",
+   "id": "27",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -429,7 +396,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "30",
+   "id": "28",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -444,7 +411,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "31",
+   "id": "29",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -459,7 +426,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "32",
+   "id": "30",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -477,7 +444,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "33",
+   "id": "31",
    "metadata": {},
    "outputs": [],
    "source": [

--- a/docs/processing_functions_tutorials/image_analysis/psf_fitting.ipynb
+++ b/docs/processing_functions_tutorials/image_analysis/psf_fitting.ipynb
@@ -22,7 +22,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "df56fbf7-cbfb-430d-9904-569ce0efd338",
+   "id": "2",
    "metadata": {},
    "source": [
     "## Install AstroVIPER\n",
@@ -33,7 +33,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "b53c55cd-62d6-4a8d-9cf0-86d855b2c679",
+   "id": "3",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -53,7 +53,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "2",
+   "id": "4",
    "metadata": {},
    "source": [
     "## Pseudo Code\n",
@@ -85,7 +85,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "3",
+   "id": "5",
    "metadata": {},
    "source": [
     "---\n",
@@ -95,7 +95,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "4",
+   "id": "6",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -109,7 +109,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "5",
+   "id": "7",
    "metadata": {},
    "source": [
     "---\n",
@@ -126,7 +126,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "6",
+   "id": "8",
    "metadata": {},
    "source": [
     "## Install AstroVIPER\n",
@@ -137,7 +137,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "7",
+   "id": "9",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -159,7 +159,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "8",
+   "id": "10",
    "metadata": {},
    "source": [
     "## Download Data"
@@ -167,7 +167,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "9",
+   "id": "11",
    "metadata": {},
    "source": [
     "Download the test CASA PSF image and convert to the XRADIO image"
@@ -176,7 +176,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "10",
+   "id": "12",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -189,7 +189,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "11",
+   "id": "13",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -200,7 +200,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "12",
+   "id": "14",
    "metadata": {},
    "source": [
     "## Import the data and run PSF gaussian fit "
@@ -208,7 +208,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "13",
+   "id": "15",
    "metadata": {},
    "source": [
     "### Import the CASA image to an XRADIO image data"
@@ -217,7 +217,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "14",
+   "id": "16",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -241,7 +241,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "15",
+   "id": "17",
    "metadata": {},
    "source": [
     "### Examine data content"
@@ -250,7 +250,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "16",
+   "id": "18",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -260,7 +260,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "17",
+   "id": "19",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -269,7 +269,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "18",
+   "id": "20",
    "metadata": {},
    "source": [
     "### Run gaussian fit on the PSF image"
@@ -277,7 +277,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "19",
+   "id": "21",
    "metadata": {},
    "source": [
     "The `point_spread_function_gaussian_fit` function returns a copy of the dataset with two new data variables, registered under a new `test_psf_fit` data group:\n",
@@ -291,7 +291,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "20",
+   "id": "22",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -316,7 +316,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "21",
+   "id": "23",
    "metadata": {},
    "source": [
     "##　Results"
@@ -325,7 +325,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "22",
+   "id": "24",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -339,7 +339,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "23",
+   "id": "25",
    "metadata": {},
    "source": [
     "### Plot the input image with the original CASA beam stored in the image for reference"
@@ -348,7 +348,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "24",
+   "id": "26",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -359,7 +359,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "25",
+   "id": "27",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -397,7 +397,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "26",
+   "id": "28",
    "metadata": {},
    "source": [
     "### Compare the fitting result with one provided in the input image"
@@ -406,7 +406,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "27",
+   "id": "29",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -429,7 +429,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "28",
+   "id": "30",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -444,7 +444,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "29",
+   "id": "31",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -459,7 +459,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "30",
+   "id": "32",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -477,7 +477,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "31",
+   "id": "33",
    "metadata": {},
    "outputs": [],
    "source": [

--- a/docs/processing_functions_tutorials/image_analysis/psf_fitting.ipynb
+++ b/docs/processing_functions_tutorials/image_analysis/psf_fitting.ipynb
@@ -13,9 +13,42 @@
    "id": "1",
    "metadata": {},
    "source": [
-    "[Colab Link](https://colab.research.google.com/github/casangi/astroviper/blob/main/docs/core_tutorials/image_analysis/psf_fitting.ipynb)\n",
+    "[Colab Link](https://colab.research.google.com/github/casangi/astroviper/blob/main/docs/processing_functions_tutorials/image_analysis/psf_fitting.ipynb)\n",
     "\n",
-    "This notebook demonstrates PSF fitting to a 2-D gaussian beam. The fitting code was adopted from https://github.com/casangi/cngi_prototype/blob/master/cngi/image/fit_gaussian.py . This demo uses a CASA PSF image converted into an XRadio image format, then fitting is performed. Simple numerical comparison with the beam parameters stored in the input CASA image are also made."
+    "This notebook demonstrates PSF fitting to a 2-D gaussian beam. The fitting code was adopted from https://github.com/casangi/cngi_prototype/blob/master/cngi/image/fit_gaussian.py . This demo uses a CASA PSF image converted into an XRadio image format, then fitting is performed. Simple numerical comparison with the beam parameters stored in the input CASA image are also made.\n",
+    "\n",
+    "---"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "df56fbf7-cbfb-430d-9904-569ce0efd338",
+   "metadata": {},
+   "source": [
+    "## Install AstroVIPER\n",
+    "\n",
+    "Skip this cell if you don't want to install the latest version of AstroVIPER."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "b53c55cd-62d6-4a8d-9cf0-86d855b2c679",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import os\n",
+    "from importlib.metadata import version\n",
+    "\n",
+    "try:\n",
+    "    os.system(\"pip install --upgrade astroviper[all]\")\n",
+    "\n",
+    "    import astroviper  # noqa: F401 -- availability probe for the pip-install fallback\n",
+    "\n",
+    "    print(\"Using astroviper version\", version(\"astroviper\"))\n",
+    "\n",
+    "except ImportError as exc:\n",
+    "    print(f\"Could not import astroviper: {exc}\")"
    ]
   },
   {
@@ -23,7 +56,6 @@
    "id": "2",
    "metadata": {},
    "source": [
-    "---\n",
     "## Pseudo Code\n",
     "\n",
     "xds_image\n",
@@ -485,7 +517,7 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "zinc",
+   "display_name": "Python 3 (ipykernel)",
    "language": "python",
    "name": "python3"
   },
@@ -499,7 +531,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.13.0"
+   "version": "3.13.7"
   }
  },
  "nbformat": 4,

--- a/docs/processing_functions_tutorials/imaging/briggs_imaging_weights.ipynb
+++ b/docs/processing_functions_tutorials/imaging/briggs_imaging_weights.ipynb
@@ -7,7 +7,7 @@
    "source": [
     "# Weight Notebook\n",
     "\n",
-    "[Colab Link](https://colab.research.google.com/github/casangi/astroviper/blob/main/docs/core_tutorials/imaging/briggs_imaging_weights.ipynb)\n",
+    "[Colab Link](https://colab.research.google.com/github/casangi/astroviper/blob/main/docs/processing_functions_tutorials/imaging/briggs_imaging_weights.ipynb)\n",
     "\n",
     "The purpose of this notebook is to demonstrate that there is agreement between CASA and AstroVIPER when calculating imaging weights using Briggs weighting with robust values of [-2, -1.45, -0.5, 0.0, 0.5, 1.33, 2].  \n",
     "Three single-field use cases will be considered: single polarization (XX), parallel hands (XX, YY), and full polarization (XX, XY, YX, YY).  \n",
@@ -90,7 +90,7 @@
     "from importlib.metadata import version\n",
     "\n",
     "try:\n",
-    "    os.system(\"pip install --upgrade astroviper\")\n",
+    "    os.system(\"pip install --upgrade astroviper[all]\")\n",
     "\n",
     "    import astroviper  # noqa: F401 -- availability probe for the pip-install fallback\n",
     "\n",
@@ -827,7 +827,7 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "timg",
+   "display_name": "Python 3 (ipykernel)",
    "language": "python",
    "name": "python3"
   },

--- a/docs/processing_functions_tutorials/imaging/cube_single_field_primary_beam.ipynb
+++ b/docs/processing_functions_tutorials/imaging/cube_single_field_primary_beam.ipynb
@@ -7,7 +7,7 @@
    "source": [
     "# Generate a single field primary beam\n",
     "\n",
-    "[Colab Link](https://colab.research.google.com/github/casangi/astroviper/blob/main/docs/core_tutorials/imaging/cube_single_field_primary_beam.ipynb)\n",
+    "[Colab Link](https://colab.research.google.com/github/casangi/astroviper/blob/main/docs/processing_functions_tutorials/imaging/cube_single_field_primary_beam.ipynb)\n",
     "\n",
     "\n",
     "\n",
@@ -71,7 +71,7 @@
     "from importlib.metadata import version\n",
     "\n",
     "try:\n",
-    "    os.system(\"pip install --upgrade astroviper\")\n",
+    "    os.system(\"pip install --upgrade astroviper[all]\")\n",
     "\n",
     "    import astroviper  # noqa: F401 -- availability probe for the pip-install fallback\n",
     "\n",
@@ -835,7 +835,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.12.11"
+   "version": "3.13.7"
   }
  },
  "nbformat": 4,

--- a/docs/processing_functions_tutorials/imaging/demo_fft_ifft_handling.ipynb
+++ b/docs/processing_functions_tutorials/imaging/demo_fft_ifft_handling.ipynb
@@ -3,7 +3,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "7f632451-4514-4e3b-9633-b56f060f5ab8",
+   "id": "0",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -13,7 +13,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "0",
+   "id": "1",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -28,7 +28,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "1",
+   "id": "2",
    "metadata": {},
    "source": [
     "# Image normalization and corrections when doing FFTs between the uv and lm domains\n",
@@ -50,7 +50,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "2",
+   "id": "3",
    "metadata": {},
    "source": [
     "## Install AstroVIPER\n",
@@ -61,7 +61,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "3",
+   "id": "4",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -81,7 +81,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "4",
+   "id": "5",
    "metadata": {},
    "source": [
     "## API note\n",
@@ -98,7 +98,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "5",
+   "id": "6",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -120,7 +120,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "6",
+   "id": "7",
    "metadata": {},
    "source": [
     "## 1. The low-level FFT pair: sky (lm) &harr; uv grid\n",
@@ -133,7 +133,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "7",
+   "id": "8",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -152,7 +152,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "8",
+   "id": "9",
    "metadata": {},
    "source": [
     "Forward transform the sky into the uv grid. The result is complex; we plot its magnitude."
@@ -161,7 +161,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "9",
+   "id": "10",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -176,7 +176,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "10",
+   "id": "11",
    "metadata": {},
    "source": [
     "Inverse transform back to the sky. For a *pure* round trip the `1/N` normalization of the inverse transform is exactly undone by the forward transform, so the sky is recovered to machine precision with no rescaling. (When imaging *gridded* visibilities you apply only the inverse transform, so you must multiply by `npix*npix` and divide by the sum of weights to restore the flux scale &mdash; see `demo_standard_grid.ipynb`.)"
@@ -185,7 +185,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "11",
+   "id": "12",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -200,7 +200,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "12",
+   "id": "13",
    "metadata": {},
    "source": [
     "## 2. Prolate-spheroidal gridding correction\n",
@@ -211,7 +211,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "13",
+   "id": "14",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -230,7 +230,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "14",
+   "id": "15",
    "metadata": {},
    "source": [
     "To see the effect, take an extended sky (a few Gaussian blobs, some near the edges), apply the taper `corrTerm` (this is what an *uncorrected* dirty image looks like), then divide by `corrTerm` to remove it. Because the taper multiplies the sky in the image domain, dividing it out recovers the original brightness exactly."
@@ -239,7 +239,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "15",
+   "id": "16",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -265,7 +265,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "16",
+   "id": "17",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -280,7 +280,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "17",
+   "id": "18",
    "metadata": {},
    "source": [
     "## 3. Padding before the FFT\n",
@@ -291,7 +291,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "18",
+   "id": "19",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -314,7 +314,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "19",
+   "id": "20",
    "metadata": {},
    "source": [
     "## 4. High-level wrappers on an image dataset\n",
@@ -327,7 +327,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "20",
+   "id": "21",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -359,7 +359,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "21",
+   "id": "22",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -386,7 +386,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "22",
+   "id": "23",
    "metadata": {},
    "outputs": [],
    "source": [

--- a/docs/processing_functions_tutorials/imaging/demo_fft_ifft_handling.ipynb
+++ b/docs/processing_functions_tutorials/imaging/demo_fft_ifft_handling.ipynb
@@ -3,6 +3,16 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "id": "7f632451-4514-4e3b-9633-b56f060f5ab8",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "!pip install mpld3"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
    "id": "0",
    "metadata": {},
    "outputs": [],
@@ -59,7 +69,7 @@
     "from importlib.metadata import version\n",
     "\n",
     "try:\n",
-    "    os.system(\"pip install --upgrade astroviper\")\n",
+    "    os.system(\"pip install --upgrade astroviper[all]\")\n",
     "\n",
     "    import astroviper  # noqa: F401 -- availability probe for the pip-install fallback\n",
     "\n",
@@ -424,7 +434,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.12.9"
+   "version": "3.13.7"
   }
  },
  "nbformat": 4,

--- a/docs/processing_functions_tutorials/imaging/demo_hogbom_clean.ipynb
+++ b/docs/processing_functions_tutorials/imaging/demo_hogbom_clean.ipynb
@@ -19,7 +19,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "fafd3f3f-03fd-47c3-9067-346acf0493d0",
+   "id": "1",
    "metadata": {},
    "source": [
     "## Install AstroVIPER\n",
@@ -30,7 +30,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "0dcd51c1-3fdc-461c-be9b-73299fb07222",
+   "id": "2",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -51,7 +51,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "1",
+   "id": "3",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -66,7 +66,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "2",
+   "id": "4",
    "metadata": {},
    "source": [
     "## Download images via toolviper"
@@ -74,7 +74,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "3",
+   "id": "5",
    "metadata": {},
    "source": [
     "Wipe any images with the same name on disk, and pull the images from the toolviper data repo in order to make the comparison between astroviper hogbom clean and CASA hogbom clean"
@@ -83,7 +83,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "4",
+   "id": "6",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -96,7 +96,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "5",
+   "id": "7",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -114,14 +114,14 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "6",
+   "id": "8",
    "metadata": {},
    "outputs": [],
    "source": []
   },
   {
    "cell_type": "markdown",
-   "id": "7",
+   "id": "9",
    "metadata": {},
    "source": [
     "## NOTE\n",
@@ -131,7 +131,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "8",
+   "id": "10",
    "metadata": {},
    "source": [
     "## Astroviper : Load images, run deconvolution\n",
@@ -144,7 +144,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "9",
+   "id": "11",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -178,7 +178,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "10",
+   "id": "12",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -222,7 +222,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "11",
+   "id": "13",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -234,7 +234,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "12",
+   "id": "14",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -244,7 +244,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "13",
+   "id": "15",
    "metadata": {},
    "source": [
     "## Results\n",
@@ -255,7 +255,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "14",
+   "id": "16",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -270,7 +270,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "15",
+   "id": "17",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -282,7 +282,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "16",
+   "id": "18",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -321,7 +321,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "17",
+   "id": "19",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -331,7 +331,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "18",
+   "id": "20",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -342,7 +342,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "19",
+   "id": "21",
    "metadata": {},
    "outputs": [],
    "source": [

--- a/docs/processing_functions_tutorials/imaging/demo_hogbom_clean.ipynb
+++ b/docs/processing_functions_tutorials/imaging/demo_hogbom_clean.ipynb
@@ -7,12 +7,45 @@
    "source": [
     "# Hogbom Deconvolve Demonstrator\n",
     "\n",
+    "[Colab Link](https://colab.research.google.com/github/casangi/astroviper/blob/main/docs/processing_functions_tutorials/imaging/demo_fhogbom_clean.ipynb)\n",
+    "\n",
     "This notebook demonstrates the implementation of Hogbom clean within the astroviper framework. \n",
     "CASA is used to generate the initial set of images (residual, PSF). The CASA task `deconvolve` is run to deconvolve the residual image. astroviper Hogbom is also run on a copy of the same images, and the two outputs are compared. \n",
     "\n",
     "This notebook is organized into three sections : The first section runs the CASA deconvolution, the second the astroviper deconvolution, and finally the comparison images and plots. \n",
     "\n",
     "This has to be done, because importing CASA alongside xradio causes some namespace conflicts and segmentation faults, so once we are done with all the CASA functionality, we will import the astroviper libraries."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "fafd3f3f-03fd-47c3-9067-346acf0493d0",
+   "metadata": {},
+   "source": [
+    "## Install AstroVIPER\n",
+    "\n",
+    "Skip this cell if you don't want to install the latest version of AstroVIPER."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "0dcd51c1-3fdc-461c-be9b-73299fb07222",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import os\n",
+    "from importlib.metadata import version\n",
+    "\n",
+    "try:\n",
+    "    os.system(\"pip install --upgrade astroviper[all]\")\n",
+    "\n",
+    "    import astroviper  # noqa: F401 -- availability probe for the pip-install fallback\n",
+    "\n",
+    "    print(\"Using astroviper version\", version(\"astroviper\"))\n",
+    "\n",
+    "except ImportError as exc:\n",
+    "    print(f\"Could not import astroviper: {exc}\")"
    ]
   },
   {
@@ -319,7 +352,7 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "timg",
+   "display_name": "Python 3 (ipykernel)",
    "language": "python",
    "name": "python3"
   },

--- a/docs/processing_functions_tutorials/imaging/demo_imaging_loop.ipynb
+++ b/docs/processing_functions_tutorials/imaging/demo_imaging_loop.ipynb
@@ -34,7 +34,9 @@
    "id": "1",
    "metadata": {},
    "source": [
-    "## Install Astroviper and Xradio (needed for colab)"
+    "## Install Astroviper\n",
+    "\n",
+    "Skip this cell if you don't want to install the latest version of AstroVIPER."
    ]
   },
   {
@@ -48,8 +50,7 @@
     "from importlib.metadata import version\n",
     "\n",
     "try:\n",
-    "    os.system('pip install \"xradio[casacore]\"')\n",
-    "    os.system(\"pip install --upgrade astroviper\")\n",
+    "    os.system(\"pip install --upgrade astroviper[all]\")\n",
     "\n",
     "    import astroviper  # noqa: F401 -- availability probe for the pip-install fallback\n",
     "\n",
@@ -618,7 +619,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.13.5"
+   "version": "3.13.7"
   }
  },
  "nbformat": 4,

--- a/docs/processing_functions_tutorials/imaging/demo_standard_degrid.ipynb
+++ b/docs/processing_functions_tutorials/imaging/demo_standard_degrid.ipynb
@@ -67,7 +67,8 @@
    "metadata": {},
    "source": [
     "## Install AstroVIPER\n",
-    "\n"
+    "\n",
+    "Skip this cell if you don't want to install the latest version of AstroVIPER."
    ]
   },
   {
@@ -81,7 +82,7 @@
     "from importlib.metadata import version\n",
     "\n",
     "try:\n",
-    "    os.system(\"pip install --upgrade astroviper\")\n",
+    "    os.system(\"pip install --upgrade astroviper[all]\")\n",
     "\n",
     "    import astroviper  # noqa: F401 -- availability probe for the pip-install fallback\n",
     "\n",
@@ -397,7 +398,7 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "timg",
+   "display_name": "Python 3 (ipykernel)",
    "language": "python",
    "name": "python3"
   },

--- a/docs/processing_functions_tutorials/imaging/demo_standard_grid.ipynb
+++ b/docs/processing_functions_tutorials/imaging/demo_standard_grid.ipynb
@@ -66,7 +66,7 @@
     "from importlib.metadata import version\n",
     "\n",
     "try:\n",
-    "    os.system(\"pip install --upgrade astroviper\")\n",
+    "    os.system(\"pip install --upgrade astroviper[all]\")\n",
     "\n",
     "    import astroviper  # noqa: F401 -- availability probe for the pip-install fallback\n",
     "\n",
@@ -636,12 +636,21 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python 3",
+   "display_name": "Python 3 (ipykernel)",
    "language": "python",
    "name": "python3"
   },
   "language_info": {
-   "name": "python"
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.13.7"
   }
  },
  "nbformat": 4,

--- a/docs/processing_functions_tutorials/imaging/demo_stokes_correlation_conversion.ipynb
+++ b/docs/processing_functions_tutorials/imaging/demo_stokes_correlation_conversion.ipynb
@@ -56,7 +56,7 @@
     "from importlib.metadata import version\n",
     "\n",
     "try:\n",
-    "    os.system(\"pip install --upgrade astroviper\")\n",
+    "    os.system(\"pip install --upgrade astroviper[all]\")\n",
     "\n",
     "    import astroviper  # noqa: F401 -- availability probe for the pip-install fallback\n",
     "\n",
@@ -604,7 +604,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.12.12"
+   "version": "3.13.7"
   }
  },
  "nbformat": 4,

--- a/docs/processing_functions_tutorials/imaging/iteration_control_demo.ipynb
+++ b/docs/processing_functions_tutorials/imaging/iteration_control_demo.ipynb
@@ -39,7 +39,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "ef46cac5-9667-4944-8d28-d254e40c4b70",
+   "id": "1",
    "metadata": {},
    "source": [
     "## Install AstroVIPER\n",
@@ -50,7 +50,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "36b56fb9-31f0-443a-8d39-93e656320e22",
+   "id": "2",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -70,7 +70,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "1",
+   "id": "3",
    "metadata": {},
    "source": [
     "---\n",
@@ -102,7 +102,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "2",
+   "id": "4",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -115,7 +115,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "3",
+   "id": "5",
    "metadata": {},
    "source": [
     "---\n",
@@ -126,7 +126,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "4",
+   "id": "6",
    "metadata": {},
    "source": [
     "## Example 1: Basic Iteration Control with Convergence\n",
@@ -136,7 +136,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "5",
+   "id": "7",
    "metadata": {},
    "source": [
     "### Setup Mock Data and Helper Functions"
@@ -145,7 +145,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "6",
+   "id": "8",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -214,7 +214,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "7",
+   "id": "9",
    "metadata": {},
    "source": [
     "### Run Basic Iteration Control Loop"
@@ -223,7 +223,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "8",
+   "id": "10",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -314,7 +314,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "9",
+   "id": "11",
    "metadata": {},
    "source": [
     "## Example 2: Different Convergence Scenarios\n",
@@ -324,7 +324,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "10",
+   "id": "12",
    "metadata": {},
    "source": [
     "### Scenario A: Iteration Limit (stopcode 1)"
@@ -333,7 +333,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "11",
+   "id": "13",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -369,7 +369,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "12",
+   "id": "14",
    "metadata": {},
    "source": [
     "### Scenario B: Major Cycle Limit (stopcode 9)"
@@ -378,7 +378,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "13",
+   "id": "15",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -415,7 +415,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "14",
+   "id": "16",
    "metadata": {},
    "source": [
     "### Scenario C: Zero Mask (stopcode 7)"
@@ -424,7 +424,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "15",
+   "id": "17",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -451,7 +451,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "16",
+   "id": "18",
    "metadata": {},
    "source": [
     "## Example 3: Interactive Parameter Updates\n",
@@ -462,7 +462,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "17",
+   "id": "19",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -547,7 +547,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "18",
+   "id": "20",
    "metadata": {},
    "source": [
     "## Example 4: ReturnDict Utilities\n",
@@ -557,7 +557,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "19",
+   "id": "21",
    "metadata": {},
    "source": [
     "### Creating ReturnDict for Multiple Planes"
@@ -566,7 +566,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "20",
+   "id": "22",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -616,7 +616,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "21",
+   "id": "23",
    "metadata": {},
    "source": [
     "### Extracting Statistics from ReturnDict"
@@ -625,7 +625,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "22",
+   "id": "24",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -646,7 +646,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "23",
+   "id": "25",
    "metadata": {},
    "source": [
     "### Merging Multiple ReturnDicts"
@@ -655,7 +655,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "24",
+   "id": "26",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -695,7 +695,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "25",
+   "id": "27",
    "metadata": {},
    "source": [
     "### Using Merged Results for Convergence Check"
@@ -703,7 +703,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "26",
+   "id": "28",
    "metadata": {},
    "source": [
     "## Example 5: Convergence History Visualization\n",
@@ -715,7 +715,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "27",
+   "id": "29",
    "metadata": {},
    "source": [
     "### Import Visualization Tools"
@@ -724,7 +724,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "28",
+   "id": "30",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -744,7 +744,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "29",
+   "id": "31",
    "metadata": {},
    "source": [
     "### Run Deconvolution with History Tracking\n",
@@ -755,7 +755,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "30",
+   "id": "32",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -842,7 +842,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "31",
+   "id": "33",
    "metadata": {},
    "source": [
     "### Create Interactive Convergence Plot\n",
@@ -860,7 +860,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "32",
+   "id": "34",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -882,7 +882,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "33",
+   "id": "35",
    "metadata": {},
    "source": [
     "### Create Plot Using Convenience Function\n",
@@ -893,7 +893,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "34",
+   "id": "36",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -907,7 +907,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "35",
+   "id": "37",
    "metadata": {},
    "source": [
     "### Multi-Channel Convergence Visualization\n",
@@ -918,7 +918,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "36",
+   "id": "38",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -998,7 +998,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "37",
+   "id": "39",
    "metadata": {},
    "outputs": [],
    "source": [

--- a/docs/processing_functions_tutorials/imaging/iteration_control_demo.ipynb
+++ b/docs/processing_functions_tutorials/imaging/iteration_control_demo.ipynb
@@ -7,7 +7,7 @@
    "source": [
     "# Iteration Control for Deconvolution\n",
     "\n",
-    "[Colab Link](https://colab.research.google.com/github/casangi/astroviper/blob/main/docs/core_tutorials/imaging/iteration_control_demo.ipynb)\n",
+    "[Colab Link](https://colab.research.google.com/github/casangi/astroviper/blob/main/docs/processing_functions_tutorials/imaging/iteration_control_demo.ipynb)\n",
     "\n",
     "This notebook demonstrates the **iteration control module** for managing major/minor cycle workflows in deconvolution algorithms. The module provides adaptive threshold calculation, convergence checking, and iteration count management compatible with CASA's behavior.\n",
     "\n",
@@ -35,6 +35,37 @@
     "  4. No valid pixels remaining (`masksum == 0`)\n",
     "\n",
     "- **ReturnDict:** A data structure holding deconvolution results (peak residual, iterations done, mask statistics, PSF info) indexed by time, polarization, and channel coordinates."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "ef46cac5-9667-4944-8d28-d254e40c4b70",
+   "metadata": {},
+   "source": [
+    "## Install AstroVIPER\n",
+    "\n",
+    "Skip this cell if you don't want to install the latest version of AstroVIPER."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "36b56fb9-31f0-443a-8d39-93e656320e22",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import os\n",
+    "from importlib.metadata import version\n",
+    "\n",
+    "try:\n",
+    "    os.system(\"pip install --upgrade astroviper[all]\")\n",
+    "\n",
+    "    import astroviper  # noqa: F401 -- availability probe for the pip-install fallback\n",
+    "\n",
+    "    print(\"Using astroviper version\", version(\"astroviper\"))\n",
+    "\n",
+    "except ImportError as exc:\n",
+    "    print(f\"Could not import astroviper: {exc}\")"
    ]
   },
   {
@@ -1005,7 +1036,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.12.12"
+   "version": "3.13.7"
   }
  },
  "nbformat": 4,

--- a/docs/processing_functions_tutorials/imaging/make_psf_demo.ipynb
+++ b/docs/processing_functions_tutorials/imaging/make_psf_demo.ipynb
@@ -9,7 +9,7 @@
     "# Make a Point Spread Function \n",
     "\n",
     "Important update the colab link:\n",
-    "[Colab Link](https://colab.research.google.com/github/casangi/astroviper/blob/main/docs/core_tutorials/imaging/make_psf_demo.ipynb)\n",
+    "[Colab Link](https://colab.research.google.com/github/casangi/astroviper/blob/main/docs/processing_function_tutorials/imaging/make_psf_demo.ipynb)\n",
     "\n",
     "\n",
     "This notebook demonstrates how to use make_psf function to create PSF image.\n",
@@ -45,7 +45,7 @@
     "from importlib.metadata import version\n",
     "\n",
     "try:\n",
-    "    os.system(\"pip install --upgrade astroviper\")\n",
+    "    os.system(\"pip install --upgrade astroviper[all]\")\n",
     "\n",
     "    import astroviper  # noqa: F401 -- availability probe for the pip-install fallback\n",
     "\n",
@@ -396,7 +396,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.12.11"
+   "version": "3.13.7"
   }
  },
  "nbformat": 4,

--- a/docs/processing_functions_tutorials/visibility_manipulation/msv4_spectral_frame_conversion_demo_comparison.ipynb
+++ b/docs/processing_functions_tutorials/visibility_manipulation/msv4_spectral_frame_conversion_demo_comparison.ipynb
@@ -7,7 +7,7 @@
    "source": [
     "# Spectral Frame Conversion Demo\n",
     "\n",
-    "[Colab Link](https://colab.research.google.com/github/casangi/astroviper/blob/main/docs/core_tutorials/imaging/msv4_spectral_frame_conversion_demo_comparison.ipynb)\n"
+    "[Colab Link](https://colab.research.google.com/github/casangi/astroviper/blob/main/docs/processing_functions_tutorials/visibility_manipulation/msv4_spectral_frame_conversion_demo_comparison.ipynb)\n"
    ]
   },
   {
@@ -31,7 +31,7 @@
     "from importlib.metadata import version\n",
     "\n",
     "try:\n",
-    "    os.system(\"pip install --upgrade astroviper\")\n",
+    "    os.system(\"pip install --upgrade astroviper[all]\")\n",
     "    import astroviper  # noqa: F401 -- availability probe for the pip-install fallback\n",
     "\n",
     "    print(\"Using astroviper version\", version(\"astroviper\"))\n",
@@ -271,7 +271,7 @@
    "notebook_metadata_filter": "-all"
   },
   "kernelspec": {
-   "display_name": "zinc",
+   "display_name": "Python 3 (ipykernel)",
    "language": "python",
    "name": "python3"
   },
@@ -285,7 +285,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.13.5"
+   "version": "3.13.7"
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
This is a partial fix for https://github.com/casangi/RADPS-roadmap/issues/185 (in AstroVIPER, this repo, other fixes are needed in xradio: https://github.com/casangi/xradio/pull/605).

The approach is to add to the notebooks the `[all]` in `pip install xradio[all]` wherever needed, as done in the GitHub CI jobs (run-ipynb-template.yml). See https://github.com/casangi/RADPS-roadmap/issues/185 for more info.

