### PR TITLE
Align PSF beam fitting and sidelobe estimation with CASA

### DIFF
--- a/src/astroviper/processing_functions/image_analysis/point_spread_function_gaussian_fit.py
+++ b/src/astroviper/processing_functions/image_analysis/point_spread_function_gaussian_fit.py
@@ -33,9 +33,9 @@ def point_spread_function_gaussian_fit(
     fit 2D gaussian to psf
 
     For every (time, frequency, polarization) slice the main lobe of the PSF is
-    isolated, a 2D Gaussian is fit to it, and the largest value found outside
-    the main lobe (the maximum sidelobe level) is recorded. Both results are
-    written back into ``img_xds`` as new data variables.
+    isolated and a 2D Gaussian is fit to it. The maximum sidelobe is measured
+    after subtracting that fitted main beam, following CASA's cycle-threshold
+    convention. Both results are written back into ``img_xds``.
 
     Parameters
     ----------
@@ -82,7 +82,7 @@ def point_spread_function_gaussian_fit(
           ``[major, minor, pa]`` for each slice.
         - ``MAX_SIDELOBE_POINT_SPREAD_FUNCTION`` with dims
           ``(time, frequency, polarization)`` holding the maximum sidelobe
-          level (the largest PSF value outside the main lobe) for each slice.
+          magnitude after subtracting the fitted main beam for each slice.
 
         The l and m coordinates of the input data are assumed to be in radians.
         The units of beam size (major and minor) and position angle are in radians.
@@ -112,8 +112,8 @@ def point_spread_function_gaussian_fit(
         )
     if not isinstance(sampling, list | tuple | np.ndarray):
         raise TypeError("sampling must be a list, tuple, or numpy array")
-    if sampling[0] <= 0 or sampling[1] <= 0:
-        raise ValueError("sampling must be positive")
+    if sampling[0] <= 1 or sampling[1] <= 1:
+        raise ValueError("sampling must contain at least two points per axis")
     if type(sampling[0]) is not int or type(sampling[1]) is not int:
         raise TypeError("sampling must be integers")
     if cutoff < 0:
@@ -176,6 +176,12 @@ def point_spread_function_gaussian_fit(
         interpolation_method,
         processing_function_threads=processing_function_threads,
     )
+    max_sidelobe = _max_sidelobe_after_gaussian_subtraction(
+        img_xds[psf_name].values,
+        ellipse_params,
+        delta,
+        fallback=max_sidelobe,
+    )
 
     # Uncomment line below to change beam_param units to arcsec and deg
     # psf_gaussian_fit_core returns bmaj and bmin in  and pa in deg.
@@ -209,6 +215,56 @@ def point_spread_function_gaussian_fit(
     )
 
     return img_xds
+
+
+def _max_sidelobe_after_gaussian_subtraction(
+    psf_image,
+    ellipse_params,
+    delta,
+    fallback=None,
+):
+    """Measure CASA-style PSF sidelobes after removing the fitted main beam."""
+    psf_image = np.asarray(psf_image)
+    ellipse_params = np.asarray(ellipse_params)
+    output = np.zeros(psf_image.shape[:3], dtype=np.float64)
+
+    for index in np.ndindex(psf_image.shape[:3]):
+        psf_2d = psf_image[index]
+        finite = np.isfinite(psf_2d)
+        beam = ellipse_params[index]
+        valid_beam = np.all(np.isfinite(beam)) and np.all(beam[:2] > 0.0)
+        if not np.any(finite) or not valid_beam:
+            if fallback is not None:
+                output[index] = fallback[index]
+            continue
+
+        finite_psf = np.where(finite, psf_2d, 0.0)
+        peak_l, peak_m = np.unravel_index(np.argmax(finite_psf), psf_2d.shape)
+        peak = finite_psf[peak_l, peak_m]
+        if peak <= 0.0:
+            if fallback is not None:
+                output[index] = fallback[index]
+            continue
+
+        l_offset = (np.arange(psf_2d.shape[0]) - peak_l) * abs(delta[0])
+        m_offset = (np.arange(psf_2d.shape[1]) - peak_m) * abs(delta[1])
+        l_grid, m_grid = np.meshgrid(l_offset, m_offset, indexing="ij")
+        cos_pa = np.cos(beam[2])
+        sin_pa = np.sin(beam[2])
+        major_offset = l_grid * cos_pa - m_grid * sin_pa
+        minor_offset = l_grid * sin_pa + m_grid * cos_pa
+        sigma_major = beam[0] / FWHM_factor
+        sigma_minor = beam[1] / FWHM_factor
+        fitted_main_beam = peak * np.exp(
+            -0.5
+            * ((major_offset / sigma_major) ** 2 + (minor_offset / sigma_minor) ** 2)
+        )
+
+        delobed_maximum = np.max(np.where(finite, psf_2d - fitted_main_beam, -np.inf))
+        original_minimum = np.min(np.where(finite, psf_2d, np.inf))
+        output[index] = max(abs(original_minimum), abs(delobed_maximum))
+
+    return output
 
 
 def _get_main_lobe_bounding_box(masked_psf_2d):
@@ -299,8 +355,10 @@ def _extract_main_lobe_2d(npix_window, threshold, psf_2d):
     main_lobe_label = labels[peak_l, peak_m]
     main_lobe_only = np.where(labels == main_lobe_label, windowed_psf, 0)
 
-    # Largest value that does not belong to the main lobe.
-    max_sidelobe = np.max(psf_2d * (labels != main_lobe_label))
+    # Cycle control depends on the largest sidelobe magnitude. A negative
+    # sidelobe is just as capable of destabilizing a minor cycle as a positive
+    # one, so do not discard it when estimating the safe cycle threshold.
+    max_sidelobe = np.max(np.abs(psf_2d) * (labels != main_lobe_label))
 
     blc, trc = _get_main_lobe_bounding_box(main_lobe_only)
     if blc is None:
@@ -417,6 +475,10 @@ def psf_gaussian_fit_core(
         back to ``os.cpu_count()``. Each slice writes to its own entry in
         the output, so results are independent of the thread count.
     """
+    sampling = np.asarray(sampling)
+    if np.any(sampling <= 1):
+        raise ValueError("sampling must contain at least two points per axis")
+
     ellipse_params = np.zeros(image_to_fit.shape[0:3] + (3,), dtype=np.float64)
     if np.all(np.isnan(image_to_fit)):
         return ellipse_params + np.nan
@@ -471,8 +533,11 @@ def psf_gaussian_fit_core(
         yp_grid = np.repeat(interp_d1, d0_shape).reshape(d1_shape, d0_shape).T
         points = np.vstack((np.ravel(xp_grid), np.ravel(yp_grid))).T
 
-        bmaj_scale = np.abs(delta[0] * FWHM_factor / (sampling[0] / npix_window[0]))
-        bmin_scale = np.abs(delta[1] * FWHM_factor / (sampling[1] / npix_window[1]))
+        # ``npix_window`` pixels span ``npix_window - 1`` intervals, and the
+        # resampled grid spans the same distance with ``sampling - 1``
+        # intervals. Convert the fitted sigma from resampled-grid units to the
+        # physical image coordinates using that interval ratio.
+        resampled_pixel_size = np.abs(delta) * (npix_window - 1) / (sampling - 1)
 
         interp_image_to_fit = np.reshape(
             interpn(
@@ -503,14 +568,16 @@ def psf_gaussian_fit_core(
         else:
             res_x = res.x
 
+        fitted_fwhm = np.abs(res_x[0:2]) * resampled_pixel_size * FWHM_factor
+
         phi = res_x[2]
-        if np.argmax(res_x[0:2]) == 1:
+        if np.argmax(fitted_fwhm) == 1:
             phi = -(np.pi / 2 - phi)
         if phi < 0:
             phi = (phi + np.pi) % np.pi
 
-        ellipse_params[time, chan, pol, 0] = np.max(np.abs(res_x[0:2])) * bmaj_scale
-        ellipse_params[time, chan, pol, 1] = np.min(np.abs(res_x[0:2])) * bmin_scale
+        ellipse_params[time, chan, pol, 0] = np.max(fitted_fwhm)
+        ellipse_params[time, chan, pol, 1] = np.min(fitted_fwhm)
         ellipse_params[time, chan, pol, 2] = phi
 
     tasks = [

--- a/tests/unit/processing_functions/image_analysis/test_psf_gaussian_fit.py
+++ b/tests/unit/processing_functions/image_analysis/test_psf_gaussian_fit.py
@@ -4,6 +4,7 @@ import xarray as xr
 
 from astroviper.processing_functions.image_analysis.point_spread_function_gaussian_fit import (
     FWHM_factor,
+    _max_sidelobe_after_gaussian_subtraction,
     extract_main_lobe,
     psf_gaussian_fit_core,
 )
@@ -142,6 +143,13 @@ def test_zero_sampling():
     ds = create_test_xds()
     with pytest.raises((ValueError, AssertionError)):
         psf_gaussian_fit(ds, sampling=[0, 9])
+
+
+def test_single_point_sampling():
+    """A resampled axis needs at least two points to define an interval."""
+    ds = create_test_xds()
+    with pytest.raises(ValueError, match="at least two points"):
+        psf_gaussian_fit(ds, sampling=[1, 9])
 
 
 def test_single_value_sampling():
@@ -374,6 +382,34 @@ def test_psf_gaussian_fit_core_simple_gaussian():
     assert np.isfinite(result[0, 0, 0, 2])
 
 
+def test_psf_gaussian_fit_core_uses_resampled_interval_scale():
+    """Resampling must preserve the physical FWHM of the original pixel grid."""
+    window_size = 17
+    sampling_size = 55
+    delta = np.array([0.2, 0.2])
+    sigma_pixels = 2.0
+    offsets = np.arange(window_size) - window_size // 2
+    l_grid, m_grid = np.meshgrid(offsets, offsets, indexing="ij")
+    gaussian = np.exp(-(l_grid**2 + m_grid**2) / (2.0 * sigma_pixels**2))[
+        None, None, None
+    ]
+
+    result = psf_gaussian_fit_core(
+        gaussian,
+        np.array([0, 0]),
+        np.array([window_size - 1, window_size - 1]),
+        np.array([sampling_size, sampling_size]),
+        0.35,
+        delta,
+        interpolation_method="splinef2d",
+    )
+
+    expected_fwhm = sigma_pixels * delta[0] * FWHM_factor
+    np.testing.assert_allclose(
+        result[0, 0, 0, :2], expected_fwhm, rtol=2.0e-3, atol=0.0
+    )
+
+
 def test_psf_gaussian_fit_core_all_nan():
     # All NaN input
     data = np.full((1, 1, 1, 9, 9), np.nan)
@@ -506,6 +542,53 @@ def test_extract_main_lobe_per_slice_independent():
     size_narrow = trc[0, 0, 0] - blc[0, 0, 0]
     size_wide = trc[0, 1, 0] - blc[0, 1, 0]
     assert np.all(size_wide > size_narrow)
+
+
+def test_extract_main_lobe_uses_largest_absolute_sidelobe():
+    """A negative sidelobe controls the minor-cycle safety threshold."""
+    data = np.zeros((1, 1, 1, 9, 9), dtype=np.float64)
+    data[0, 0, 0, 4, 4] = 1.0
+    data[0, 0, 0, 1, 1] = 0.2
+    data[0, 0, 0, 7, 7] = -0.4
+
+    _, _, _, max_sidelobe = extract_main_lobe(np.array([9, 9]), 0.35, data)
+
+    np.testing.assert_allclose(max_sidelobe, [[[0.4]]])
+
+
+def test_gaussian_subtraction_removes_main_beam_before_sidelobe_measurement():
+    """A fitted main beam is removed while a separate sidelobe remains."""
+    axis = np.arange(51) - 25
+    l_grid, m_grid = np.meshgrid(axis, axis, indexing="ij")
+    sigma = 4.0
+    psf = np.exp(-0.5 * (l_grid**2 + m_grid**2) / sigma**2)
+    psf[5, 5] += 0.25
+    data = psf[None, None, None, ...]
+    beam = np.array([[[[sigma * FWHM_factor, sigma * FWHM_factor, 0.0]]]])
+
+    result = _max_sidelobe_after_gaussian_subtraction(
+        data,
+        beam,
+        np.array([1.0, 1.0]),
+    )
+
+    np.testing.assert_allclose(result, [[[0.25]]], atol=1e-12)
+
+
+def test_gaussian_subtraction_keeps_negative_sidelobe_magnitude():
+    """CASA-style sidelobes include the magnitude of the PSF minimum."""
+    data = np.zeros((1, 1, 1, 21, 21), dtype=np.float64)
+    data[0, 0, 0, 10, 10] = 1.0
+    data[0, 0, 0, 2, 2] = -0.4
+    beam = np.array([[[[FWHM_factor, FWHM_factor, 0.0]]]])
+
+    result = _max_sidelobe_after_gaussian_subtraction(
+        data,
+        beam,
+        np.array([1.0, 1.0]),
+    )
+
+    np.testing.assert_allclose(result, [[[0.4]]])
 
 
 def test_psf_gaussian_fit_core_per_slice_boxes():


### PR DESCRIPTION
- correct Gaussian beam scaling using resampled pixel intervals
- subtract the fitted main beam before measuring PSF sidelobes
- include negative sidelobes in the cycle-threshold estimate
- add regression tests for beam recovery and sidelobe measurement

References: b2cf314, be9825b