### PR TITLE
Add CASA-style stability checks for long Högbom CLEAN cycles

### DIFF
--- a/src/astroviper/processing_functions/imaging/deconvolution.py
+++ b/src/astroviper/processing_functions/imaging/deconvolution.py
@@ -714,6 +714,98 @@ def deconvolve(
     return returndict
 
 
+def _hogbom_peak_cube(residual_cube, mask_cube, clean_box):
+    """Return the absolute residual peak in each CLEAN search region."""
+    _, _, _, ny, nx = residual_cube.shape
+    xbeg, xend, ybeg, yend = clean_box
+    xbeg = 0 if xbeg == -1 else max(0, min(xbeg, nx - 1))
+    xend = nx if xend == -1 else max(xbeg + 1, min(xend, nx))
+    ybeg = 0 if ybeg == -1 else max(0, min(ybeg, ny - 1))
+    yend = ny if yend == -1 else max(ybeg + 1, min(yend, ny))
+
+    search = np.abs(residual_cube[..., ybeg:yend, xbeg:xend])
+    if mask_cube is not None:
+        search = np.where(
+            mask_cube[..., ybeg:yend, xbeg:xend],
+            search,
+            0.0,
+        )
+    return np.max(search, axis=(-2, -1))
+
+
+def _run_hogbom_with_cycle_checks(
+    clean_cube,
+    *,
+    residual_cube,
+    psf_cube,
+    model_cube,
+    peak_mask_cube,
+    mask_arg,
+    clean_box,
+    niter_cube,
+    cyclethreshold_cube,
+    gain,
+    processing_function_threads,
+):
+    """Run CASA-sized CLEAN batches and stop planes whose residual diverges."""
+    iterations = np.zeros(niter_cube.shape, dtype=np.int64)
+    final_peak = _hogbom_peak_cube(residual_cube, peak_mask_cube, clean_box)
+    minimum_peak = final_peak.copy()
+    diverged = np.zeros(niter_cube.shape, dtype=bool)
+
+    active = (niter_cube > 0) & (final_peak > cyclethreshold_cube)
+    while np.any(active):
+        remaining = np.maximum(niter_cube - iterations, 0)
+        # CASA checks long minor cycles after 2000 iterations. Cycles shorter
+        # than 5000 iterations are executed as a single batch.
+        batch_niter = np.where(
+            remaining < 5000,
+            remaining,
+            np.minimum(remaining, 2000),
+        )
+        batch_niter = np.where(active, batch_niter, 0).astype(niter_cube.dtype)
+        batch_niter = np.ascontiguousarray(batch_niter)
+
+        result = clean_cube(
+            residual_cube=residual_cube,
+            psf_cube=psf_cube,
+            model_cube=model_cube,
+            mask_cube=mask_arg,
+            clean_box=clean_box,
+            max_iter=batch_niter,
+            gain=gain,
+            threshold=cyclethreshold_cube,
+            processing_function_threads=int(processing_function_threads),
+        )
+        performed = np.asarray(result["iterations_performed"], dtype=np.int64)
+        current_peak = np.asarray(result["final_peak"], dtype=final_peak.dtype)
+        iterations += performed
+        final_peak = np.where(active, current_peak, final_peak)
+
+        finite_minimum = np.isfinite(minimum_peak) & (minimum_peak > 0.0)
+        rose_from_minimum = finite_minimum & (final_peak > 1.1 * minimum_peak)
+        nonfinite = ~np.isfinite(final_peak)
+        diverged |= active & (rose_from_minimum | nonfinite)
+        minimum_peak = np.where(
+            np.isfinite(final_peak) & (final_peak < minimum_peak),
+            final_peak,
+            minimum_peak,
+        )
+
+        converged = final_peak <= cyclethreshold_cube
+        exhausted = iterations >= niter_cube
+        no_progress = performed <= 0
+        active &= ~(converged | exhausted | diverged | no_progress)
+
+    return {
+        "iterations_performed": iterations,
+        "final_peak": final_peak,
+        "total_flux_cleaned": np.sum(np.abs(model_cube), axis=(-2, -1)),
+        "converged": final_peak <= cyclethreshold_cube,
+        "diverged": diverged,
+    }
+
+
 def hogbom_clean(
     residual_cube: np.ndarray,
     psf_cube: np.ndarray,
@@ -770,7 +862,8 @@ def hogbom_clean(
     dict
         Per-plane summary arrays with shape ``(nt, nf, np)`` and keys
         ``iterations_performed`` (int), ``final_peak`` (float),
-        ``total_flux_cleaned`` (float), and ``converged`` (bool). The
+        ``total_flux_cleaned`` (float), ``converged`` (bool), and ``diverged``
+        (bool). The
         final residual and model cubes are the caller-supplied arrays,
         updated in place.
 
@@ -847,15 +940,17 @@ def hogbom_clean(
         deconvolve_params, nt, nf, npol_img, residual_cube.dtype
     )
 
-    return hogbom.clean_cube(
+    return _run_hogbom_with_cycle_checks(
+        hogbom.clean_cube,
         residual_cube=residual_cube,
         psf_cube=psf_cube,
         model_cube=model_cube,
-        mask_cube=mask_arg,
+        peak_mask_cube=mask_cube,
+        mask_arg=mask_arg,
         clean_box=clean_box,
-        max_iter=niter_cube,
+        niter_cube=niter_cube,
         gain=deconvolve_params["gain"],
-        threshold=cyclethreshold_cube,
+        cyclethreshold_cube=cyclethreshold_cube,
         processing_function_threads=int(processing_function_threads),
     )
 
@@ -936,15 +1031,17 @@ def hogbom_clean_many_threads(
         deconvolve_params, nt, nf, npol_img, residual_cube.dtype
     )
 
-    return hogbom.clean_cube_many_threads(
+    return _run_hogbom_with_cycle_checks(
+        hogbom.clean_cube_many_threads,
         residual_cube=residual_cube,
         psf_cube=psf_cube,
         model_cube=model_cube,
-        mask_cube=mask_arg,
+        peak_mask_cube=mask_cube,
+        mask_arg=mask_arg,
         clean_box=clean_box,
-        max_iter=niter_cube,
+        niter_cube=niter_cube,
         gain=deconvolve_params["gain"],
-        threshold=cyclethreshold_cube,
+        cyclethreshold_cube=cyclethreshold_cube,
         processing_function_threads=int(processing_function_threads),
     )
 

--- a/tests/unit/processing_functions/imaging/test_deconvolution.py
+++ b/tests/unit/processing_functions/imaging/test_deconvolution.py
@@ -24,6 +24,7 @@ import xarray as xr
 
 from astroviper.processing_functions.imaging.deconvolution import (
     _plane_peak_abs_signed,
+    _run_hogbom_with_cycle_checks,
     _validate_deconvolve_params,
     asp_clean,
     deconvolve,
@@ -338,6 +339,39 @@ class TestGetPhaseCenter:
 
 @requires_hogbom
 class TestHogbomCleanCube:
+    def test_long_cycle_stops_when_residual_rises_from_minimum(self):
+        """Long CLEAN cycles use CASA-sized batches and its 10% divergence test."""
+        residual = np.ones((1, 1, 1, 1, 1), dtype=np.float64)
+        model = np.zeros_like(residual)
+        calls = []
+
+        def fake_clean_cube(**kwargs):
+            calls.append(int(kwargs["max_iter"].item()))
+            peak = 0.8 if len(calls) == 1 else 0.9
+            kwargs["residual_cube"][...] = peak
+            return {
+                "iterations_performed": kwargs["max_iter"].copy(),
+                "final_peak": np.full((1, 1, 1), peak),
+            }
+
+        result = _run_hogbom_with_cycle_checks(
+            fake_clean_cube,
+            residual_cube=residual,
+            psf_cube=np.ones_like(residual),
+            model_cube=model,
+            peak_mask_cube=None,
+            mask_arg=np.array([], dtype=np.float64),
+            clean_box=(-1, -1, -1, -1),
+            niter_cube=np.full((1, 1, 1), 10000, dtype=np.int64),
+            cyclethreshold_cube=np.zeros((1, 1, 1), dtype=np.float64),
+            gain=0.1,
+            processing_function_threads=1,
+        )
+
+        assert calls == [2000, 2000]
+        assert result["iterations_performed"].item() == 4000
+        assert result["diverged"].item()
+
     def test_basic_cube_cleaned(self):
         nt, nf, npol, ny, nx = 1, 1, 1, 16, 16
         resid = np.zeros((nt, nf, npol, ny, nx), dtype=np.float32)


### PR DESCRIPTION
- split long CLEAN cycles into CASA-style 2000-iteration batches
- monitor the minimum residual peak independently for each image plane
- stop planes when residuals rise by more than 10 percent from their minimum
- detect non-finite residuals and expose per-plane divergence status
- apply the same safeguards to both Högbom execution paths
- add regression coverage for long-cycle divergence detection

This brings AstroVIPER’s Högbom cycle control closer to CASA while preserving its per-plane execution model.

Reference: be9825b