### PR TITLE
Refactor cube degridding around a shared low-level primitive

### DIFF
--- a/src/astroviper/processing_functions/imaging/degrid_visibility_grid.py
+++ b/src/astroviper/processing_functions/imaging/degrid_visibility_grid.py
@@ -1,0 +1,139 @@
+"""Shared standard-gridder visibility prediction primitive."""
+
+import copy
+
+import numpy as np
+import xarray as xr
+
+from astroviper.utils.data_group_tools import (
+    create_data_groups_in_and_out,
+    modify_data_groups_xds,
+)
+
+
+def degrid_visibility_grid_single_field(
+    ms_xds: xr.Dataset,
+    cgk_1D: np.ndarray,
+    img_xds: xr.Dataset,
+    grid: np.ndarray,
+    frequency_map: np.ndarray,
+    ms_data_group_in_name: str = "base",
+    ms_data_group_out_name: str = "model",
+    ms_data_group_out_modified: dict | None = None,
+    overwrite: bool = True,
+    fft_padding: float = 1.2,
+    processing_function_threads: int = 1,
+    description: str = "Degridded standard-gridder model visibilities.",
+):
+    """Sample a prepared UV grid directly onto visibility coordinates.
+
+    This is the shared numerical primitive beneath cube and continuum model
+    prediction. Callers own the spectral representation of ``grid`` and supply
+    the mapping from each visibility channel to its corresponding grid plane.
+
+    Parameters
+    ----------
+    ms_xds : xarray.Dataset
+        Measurement-set partition modified in place with model visibilities.
+    cgk_1D : numpy.ndarray
+        One-dimensional prolate-spheroidal convolution kernel.
+    img_xds : xarray.Dataset
+        Image geometry supplying direction-cell sizes and unpadded image shape.
+    grid : numpy.ndarray
+        C-contiguous UV grid with dimensions
+        ``(time, spectral_plane, polarization, u, v)``.
+    frequency_map : numpy.ndarray
+        Integer grid-plane index for every visibility frequency channel.
+    ms_data_group_in_name, ms_data_group_out_name : str
+        Input and output measurement-set data-group names.
+    ms_data_group_out_modified : dict, optional
+        Output role-to-variable mapping. Defaults to
+        ``{"correlated_data": "VISIBILITY_MODEL"}``.
+    overwrite : bool
+        Whether an existing output data group may be replaced.
+    fft_padding : float
+        FFT padding used to derive the UV-grid shape from the image geometry.
+    processing_function_threads : int
+        Threads supplied to the C++ degridder.
+    description : str
+        Description stored with a newly registered output data group.
+
+    Returns
+    -------
+    None
+        ``ms_xds`` is modified in place.
+    """
+    if ms_data_group_out_modified is None:
+        ms_data_group_out_modified = {"correlated_data": "VISIBILITY_MODEL"}
+
+    output_mapping = copy.deepcopy(ms_data_group_out_modified)
+    ms_data_group_in, ms_data_group_out = create_data_groups_in_and_out(
+        ms_xds,
+        data_group_in_name=ms_data_group_in_name,
+        data_group_out_name=ms_data_group_out_name,
+        data_group_out_modified=output_mapping,
+        overwrite=overwrite,
+    )
+
+    frequency_map = np.ascontiguousarray(frequency_map, dtype=np.int64)
+    n_chan = ms_xds.sizes["frequency"]
+    if frequency_map.shape != (n_chan,):
+        raise ValueError(
+            "frequency_map must contain one grid-plane index per visibility "
+            f"channel; received shape {frequency_map.shape} for {n_chan} channels."
+        )
+
+    grid = np.ascontiguousarray(grid)
+    if grid.ndim != 5:
+        raise ValueError(
+            "grid must have dimensions (time, spectral_plane, polarization, u, v)."
+        )
+    if np.any(frequency_map < 0) or np.any(frequency_map >= grid.shape[1]):
+        raise ValueError("frequency_map contains an index outside the UV grid.")
+
+    output_name = ms_data_group_out["correlated_data"]
+    if output_name not in ms_xds:
+        input_visibility = ms_xds[ms_data_group_in["correlated_data"]]
+        ms_xds[output_name] = xr.DataArray(
+            np.zeros(input_visibility.shape, dtype=np.complex128),
+            dims=input_visibility.dims,
+        )
+        modify_data_groups_xds(
+            ms_xds,
+            ms_data_group_out_name,
+            ms_data_group_out,
+            description=description,
+        )
+
+    vis_data = ms_xds[output_name].values
+    uvw = np.ascontiguousarray(ms_xds[ms_data_group_in["uvw"]].values)
+    frequency_coord = np.ascontiguousarray(ms_xds.frequency.values, dtype=np.float64)
+    time_map = np.zeros(ms_xds.sizes["time"], dtype=np.int64)
+    pol_map = np.arange(ms_xds.sizes["polarization"], dtype=np.int64)
+
+    from astroviper.processing_functions.imaging.utils.fft_sizing import (
+        padded_grid_size,
+    )
+
+    n_uv = padded_grid_size([img_xds.sizes["l"], img_xds.sizes["m"]], fft_padding)
+    delta_lm = img_xds.xr_img.get_lm_cell_size()
+
+    from astroviper.processing_functions.imaging.gridders.prolate_spheroidal_grid_cpp import (
+        prolate_spheroidal_degrid,
+    )
+
+    prolate_spheroidal_degrid(
+        grid,
+        vis_data,
+        uvw,
+        frequency_coord,
+        frequency_map,
+        time_map,
+        pol_map,
+        cgk_1D,
+        n_uv,
+        delta_lm,
+        support=7,
+        oversampling=100,
+        processing_function_threads=processing_function_threads,
+    )

--- a/src/astroviper/processing_functions/imaging/get_visibility_grid.py
+++ b/src/astroviper/processing_functions/imaging/get_visibility_grid.py
@@ -1,12 +1,5 @@
-import copy
-
 import numpy as np
 import xarray as xr
-
-from astroviper.utils.data_group_tools import (
-    create_data_groups_in_and_out,
-    modify_data_groups_xds,
-)
 
 
 def get_visibility_grid_single_field(
@@ -37,8 +30,9 @@ def get_visibility_grid_single_field(
     :func:`~astroviper.processing_functions.imaging.add_visibility_grid.add_visibility_grid_single_field`:
     it predicts visibilities *from* a UV-plane model rather than gridding
     observed visibilities onto a UV plane.  It uses the standard separable
-    prolate-spheroidal degridder (the C++ ``prolate_spheroidal_degrid``
-    kernel) and therefore does not require a GCF dataset.
+    C++ prolate-spheroidal degridder and therefore does not require a GCF
+    dataset. Cube and continuum callers share that numerical primitive without
+    sharing their spectral-model preparation APIs.
 
     Parameters
     ----------
@@ -51,7 +45,7 @@ def get_visibility_grid_single_field(
     cgk_1D : np.ndarray
         Oversampled 1-D prolate spheroidal wave function (PSWF) kernel.
         Shape ``(oversampling * (support // 2 + 1),)``; passed directly to
-        the C++ ``prolate_spheroidal_degrid`` kernel.
+        the standard degridder.
     img_xds : xr.Dataset
         Image dataset holding the model UV grid.  Must expose an image data
         group under ``image_data_group_in_name`` whose ``"SKY"`` role names a
@@ -79,8 +73,7 @@ def get_visibility_grid_single_field(
         own image channel; ``"continuum"`` sources every visibility channel
         from image channel 0.
     processing_function_threads : int, default ``1``
-        Number of threads used by the C++ degridder; ``<= 0`` falls back to
-        the hardware concurrency.
+        Number of threads supplied to the C++ degridder.
 
     Returns
     -------
@@ -91,8 +84,8 @@ def get_visibility_grid_single_field(
     Notes
     -----
     - Flags must be applied by the caller before invoking this function.  The
-      underlying C++ ``prolate_spheroidal_degrid`` kernel has no flag argument
-      and only skips samples whose ``vis_data`` value is ``NaN``.  Newly
+      underlying degridder has no flag argument and only skips samples whose
+      ``vis_data`` value is ``NaN``. Newly
       allocated output arrays are zero-initialised (not ``NaN``), so every
       visibility whose ``uvw`` is finite and whose support falls inside the
       grid will receive a prediction.
@@ -103,101 +96,48 @@ def get_visibility_grid_single_field(
     --------
     astroviper.processing_functions.imaging.add_visibility_grid.add_visibility_grid_single_field :
         Forward (gridding) counterpart.
-    astroviper.processing_functions.imaging.gridders.prolate_spheroidal_grid_cpp.prolate_spheroidal_degrid :
-        C++ standard separable degridding kernel.
+    degrid_visibility_grid_single_field :
+        Shared standard-gridder numerical primitive.
     """
     if ms_data_group_out_modified is None:
         ms_data_group_out_modified = {
             "correlated_data": "VISIBILITY_MODEL",
         }
-    _ms_data_group_out_modified = copy.deepcopy(ms_data_group_out_modified)
-
-    # Resolve the image input and output data groups, guarding against
-    # accidental overwrites according to the overwrite flag.
-    ms_data_group_in, ms_data_group_out = create_data_groups_in_and_out(
-        ms_xds,
-        data_group_in_name=ms_data_group_in_name,
-        data_group_out_name=ms_data_group_out_name,
-        data_group_out_modified=_ms_data_group_out_modified,
-        overwrite=overwrite,
-    )
-
     model_name = img_xds.attrs["data_groups"][image_data_group_in_name]["visibility"]
 
-    n_chan = img_xds.sizes["frequency"]
+    n_chan = ms_xds.sizes["frequency"]
     if chan_mode == "cube":
-        frequency_map = (np.arange(0, n_chan)).astype(int)
+        from astroviper.processing_functions.imaging.utils.frequency_mapping import (
+            map_visibility_frequencies_to_image,
+        )
+
+        frequency_map = map_visibility_frequencies_to_image(
+            ms_xds.frequency.values,
+            img_xds.frequency.values,
+        )
     else:  # continuum
-        # Single continuum image collapsed across all channels.
         frequency_map = (np.zeros(n_chan)).astype(int)
 
-    # Time Map #Currently not implemented.
-    n_time = ms_xds.sizes["time"]
-    time_map = (np.zeros(n_time)).astype(int)
-
-    n_imag_pol = img_xds.sizes["polarization"]
-    pol_map = (np.arange(0, n_imag_pol)).astype(int)
-
-    from astroviper.processing_functions.imaging.utils.fft_sizing import (
-        padded_grid_size,
+    grid = np.ascontiguousarray(img_xds[model_name].values)
+    from astroviper.processing_functions.imaging.degrid_visibility_grid import (
+        degrid_visibility_grid_single_field,
     )
 
-    n_uv = padded_grid_size([img_xds.sizes["l"], img_xds.sizes["m"]], fft_padding)
-    delta_lm = img_xds.xr_img.get_lm_cell_size()
-
-    # Initialise the output visibility array on the first call; subsequent
-    # calls reuse (and overwrite) the existing data variable in place.
-    # The model visibilities are kept double precision (complex128): the
-    # visibilities stay double even when the image-domain model grid is single
-    # precision, and the residual = observed - model is formed in double
-    # precision. The C++ degridder widens each (possibly complex64) model-grid
-    # cell to complex128 for the accumulation, so it can write complex128 here.
-    if ms_data_group_out["correlated_data"] not in ms_xds:
-        ms_xds[ms_data_group_out["correlated_data"]] = xr.DataArray(
-            np.zeros(
-                (
-                    ms_xds.sizes["time"],
-                    ms_xds.sizes["baseline_id"],
-                    ms_xds.sizes["frequency"],
-                    ms_xds.sizes["polarization"],
-                ),
-                dtype=np.complex128,
-            ),
-            dims=["time", "baseline_id", "frequency", "polarization"],
-        )
-
-        modify_data_groups_xds(
-            ms_xds,
-            ms_data_group_out_name,
-            ms_data_group_out,
-            description="Degridded visibilities from img_xds "
-            + image_data_group_in_name
-            + " to ms_xds "
-            + ms_data_group_out_name
-            + " with get_visibility_grid_single_field.",
-        )
-
-    grid = img_xds[model_name].values
-    vis_data = ms_xds[ms_data_group_out["correlated_data"]].values
-    uvw = ms_xds[ms_data_group_in["uvw"]].values
-    frequency_coord = ms_xds.frequency.values
-
-    from astroviper.processing_functions.imaging.gridders.prolate_spheroidal_grid_cpp import (
-        prolate_spheroidal_degrid,
-    )
-
-    prolate_spheroidal_degrid(
-        grid,
-        vis_data,
-        uvw,
-        frequency_coord,
-        frequency_map,
-        time_map,
-        pol_map,
+    degrid_visibility_grid_single_field(
+        ms_xds,
         cgk_1D,
-        n_uv,
-        delta_lm,
-        support=7,
-        oversampling=100,
+        img_xds,
+        grid,
+        frequency_map,
+        ms_data_group_in_name=ms_data_group_in_name,
+        ms_data_group_out_name=ms_data_group_out_name,
+        ms_data_group_out_modified=ms_data_group_out_modified,
+        overwrite=overwrite,
+        fft_padding=fft_padding,
         processing_function_threads=processing_function_threads,
+        description="Degridded visibilities from img_xds "
+        + image_data_group_in_name
+        + " to ms_xds "
+        + ms_data_group_out_name
+        + " with get_visibility_grid_single_field.",
     )

--- a/tests/unit/processing_functions/imaging/test_get_visibility_grid.py
+++ b/tests/unit/processing_functions/imaging/test_get_visibility_grid.py
@@ -19,6 +19,9 @@ import xarray as xr
 # Registers the `xr_img` accessor used by the function under test.
 import xradio.image.image_xds  # noqa: F401
 
+from astroviper.processing_functions.imaging.degrid_visibility_grid import (
+    degrid_visibility_grid_single_field,
+)
 from astroviper.processing_functions.imaging.get_visibility_grid import (
     get_visibility_grid_single_field,
 )
@@ -195,6 +198,48 @@ class TestGetVisibilityGridSingleField(unittest.TestCase):
         get_visibility_grid_single_field(ms_xds, cgk, img_xds)
         with self.assertRaises(AssertionError):
             get_visibility_grid_single_field(ms_xds, cgk, img_xds, overwrite=False)
+
+    def test_shared_primitive_rejects_frequency_map_with_wrong_length(self):
+        """The frequency map must contain one entry per visibility channel."""
+        ms_xds, img_xds, _ = _build_datasets(n_chan=2)
+        cgk = create_prolate_spheroidal_kernel_1D(OVERSAMPLING, SUPPORT)
+
+        with self.assertRaisesRegex(ValueError, "one grid-plane index"):
+            degrid_visibility_grid_single_field(
+                ms_xds,
+                cgk,
+                img_xds,
+                img_xds["SKY_MODEL"].values,
+                np.array([0], dtype=np.int64),
+            )
+
+    def test_shared_primitive_rejects_non_five_dimensional_grid(self):
+        """The shared primitive requires a five-dimensional UV grid."""
+        ms_xds, img_xds, _ = _build_datasets(n_chan=2)
+        cgk = create_prolate_spheroidal_kernel_1D(OVERSAMPLING, SUPPORT)
+
+        with self.assertRaisesRegex(ValueError, "grid must have dimensions"):
+            degrid_visibility_grid_single_field(
+                ms_xds,
+                cgk,
+                img_xds,
+                img_xds["SKY_MODEL"].values[0],
+                np.array([0, 1], dtype=np.int64),
+            )
+
+    def test_shared_primitive_rejects_out_of_range_frequency_map(self):
+        """Every mapped visibility channel must name an existing grid plane."""
+        ms_xds, img_xds, _ = _build_datasets(n_chan=2)
+        cgk = create_prolate_spheroidal_kernel_1D(OVERSAMPLING, SUPPORT)
+
+        with self.assertRaisesRegex(ValueError, "outside the UV grid"):
+            degrid_visibility_grid_single_field(
+                ms_xds,
+                cgk,
+                img_xds,
+                img_xds["SKY_MODEL"].values,
+                np.array([0, 2], dtype=np.int64),
+            )
 
     # ------------------------------------------------------------------
     # Skip behaviour


### PR DESCRIPTION
- move data-group handling, output allocation, geometry preparation, and C++ degridding into a reusable processing function
- retain cube-specific frequency mapping in the cube degridding entry point
- explicitly map visibility channels onto their corresponding image planes
- validate grid dimensions and frequency-map bounds
- add regression tests for the shared primitive’s input contracts
- verify that cube execution is bit-identical to the previous implementation, with a maximum absolute difference of zero

This separates cube spectral-model preparation from the common numerical degridding path and prepares the primitive for later continuum reuse without changing cube results.

Reference: 16f67ef