### PR TITLE
Ensure model grids are contiguous before cube degridding

### DIFF
--- a/src/astroviper/processing_functions/imaging/get_visibility_grid.py
+++ b/src/astroviper/processing_functions/imaging/get_visibility_grid.py
@@ -177,7 +177,7 @@ def get_visibility_grid_single_field(
             + " with get_visibility_grid_single_field.",
         )
 
-    grid = img_xds[model_name].values
+    grid = np.ascontiguousarray(img_xds[model_name].values)
     vis_data = ms_xds[ms_data_group_out["correlated_data"]].values
     uvw = ms_xds[ms_data_group_in["uvw"]].values
     frequency_coord = ms_xds.frequency.values

--- a/tests/unit/processing_functions/imaging/test_get_visibility_grid.py
+++ b/tests/unit/processing_functions/imaging/test_get_visibility_grid.py
@@ -147,6 +147,32 @@ class TestGetVisibilityGridSingleField(unittest.TestCase):
         out = ms_xds["VISIBILITY_MODEL"].values
         self.assertTrue(np.all(out == 0.0))
 
+    def test_noncontiguous_model_grid_matches_contiguous_grid(self):
+        """A strided model-grid view is copied before entering the C++ kernel."""
+        contiguous_ms, contiguous_img, _ = _build_datasets(seed=42, sky_value=0.0j)
+        strided_ms, strided_img, _ = _build_datasets(seed=42, sky_value=0.0j)
+        rng = np.random.default_rng(7)
+        shape = contiguous_img["SKY_MODEL"].shape
+        model_grid = (
+            rng.standard_normal(shape) + 1j * rng.standard_normal(shape)
+        ).astype(np.complex128)
+        contiguous_img["SKY_MODEL"].data = model_grid.copy()
+
+        backing = np.empty(shape[:-1] + (2 * shape[-1],), dtype=np.complex128)
+        strided_grid = backing[..., ::2]
+        strided_grid[...] = model_grid
+        self.assertFalse(strided_grid.flags.c_contiguous)
+        strided_img["SKY_MODEL"].data = strided_grid
+
+        cgk = create_prolate_spheroidal_kernel_1D(OVERSAMPLING, SUPPORT)
+        get_visibility_grid_single_field(contiguous_ms, cgk, contiguous_img)
+        get_visibility_grid_single_field(strided_ms, cgk, strided_img)
+
+        np.testing.assert_array_equal(
+            strided_ms["VISIBILITY_MODEL"].values,
+            contiguous_ms["VISIBILITY_MODEL"].values,
+        )
+
     # ------------------------------------------------------------------
     # Dataset plumbing
     # ------------------------------------------------------------------


### PR DESCRIPTION
- convert model grids to C-contiguous arrays at the C++ degridding boundary
- support strided and otherwise non-contiguous xarray-backed grid views
- preserve zero-copy behavior when model grids are already contiguous
- add regression coverage comparing contiguous and strided model grids
- verify that ordinary cube execution remains bit-identical to the previous implementation, with a maximum absolute difference of zero

The cube-side correction is intentionally trivial because cube model grids are normally already contiguous. It has greater importance for the continuum workflow, where Taylor reconstruction, transposition, and xarray operations can produce non-contiguous grid views before degridding.

Reference: 9d0328f